### PR TITLE
docs: obsidian documentation vault, secret-scanning guardrails, sync automation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"MANDATORY: graphify-out/graph.json exists. You MUST run `graphify query \\\"<question>\\\"` before grepping raw files. Only grep after graphify has oriented you, or to modify/debug specific lines.\"}}'   || true ;; esac"
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "HIT=$(python3 -c \"import json,sys;d=json.load(sys.stdin);t=d.get('tool_input',d);s=(str(t.get('file_path') or '')+' '+str(t.get('pattern') or '')+' '+str(t.get('path') or '')).lower().replace(chr(92),'/');exts=('.py','.js','.ts','.tsx','.jsx','.go','.rs','.java','.rb','.c','.h','.cpp','.hpp','.cc','.cs','.kt','.swift','.php','.scala','.lua','.sh','.md','.rst','.txt','.mdx');sys.stdout.write('1' if 'graphify-out/' not in s and any(e in s for e in exts) else '')\" 2>/dev/null || true); if [ \"$HIT\" = 1 ] && [ -f graphify-out/graph.json ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"MANDATORY: graphify-out/graph.json exists. You MUST run graphify before reading source files. Use: `graphify query \\\"<question>\\\"` (scoped subgraph), `graphify explain \\\"<concept>\\\"`, or `graphify path \\\"<A>\\\" \\\"<B>\\\"`. Only read raw files after graphify has oriented you, or to modify/debug specific lines. This rule applies to subagents too \u2014 include it in every subagent prompt involving code exploration.\"}}'; fi || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,22 @@ on:
 permissions: {}
 
 jobs:
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # full history — gitleaks scans every commit
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ go.work
 
 # Kubeconfig might contain secrets
 *.kubeconfig
+
+# graphify knowledge-graph build artifacts
+graphify-out/
+
+# generated obsidian knowledge-graph vault (regenerate: graphify export obsidian --dir obsidian/graph)
+obsidian/graph/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,19 @@
+# gitleaks configuration for k8s-r8r (public repo — every push is scanned)
+# Local gate: pre-push hook (make install-hooks). Server gate: CI job.
+
+[extend]
+# Start from gitleaks' built-in default ruleset.
+useDefault = true
+
+[allowlist]
+description = "Known-safe fixtures and generated material"
+paths = [
+  # e2e testdata: minimal CAPI CRD stub, contains no credentials
+  '''test/e2e/testdata/.*''',
+  # helm chart golden values: placeholder-only
+  '''charts/k8s-r8r/values\.yaml''',
+]
+regexes = [
+  # obviously-fake placeholders used in docs and tests
+  '''REDACTED|CHANGEME|example\.com|fake-token|dummy''',
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# k8s-r8r — project instructions
+
+Public repository. Kubernetes operator for policy-gated cross-cluster object replication. Entry points: `README.md`, `obsidian/k8s-r8r.md` (documentation hub), `openspec/` (behavior specs).
+
+## Workflow contract (every change)
+
+1. **Spec first**: behavior changes go through OpenSpec (`openspec new change`, `/opsx:*` flow). Specs in `openspec/specs` are the source of truth; keep them in sync with implementation.
+2. **Docs are part of done**: after any functional change, update the affected note(s) in `obsidian/` (curated vault — one note per functionality, `[[wikilinks]]`, hub `obsidian/k8s-r8r.md`) and the relevant `docs/*.md` in the same session. Never leave doc updates as follow-ups.
+3. **Knowledge graph**: regenerate incrementally after substantive changes — `/graphify --update`, then `graphify export obsidian --dir obsidian/graph`. Code-only changes are covered by the post-commit hook.
+4. **Tests before push**: `make lint && make test` minimum; e2e (`make test-e2e`, needs docker) for engine/discovery/transport changes.
+
+## Hard rules
+
+- **No sensitive data ever** — real credentials, kubeconfigs, tokens, personal data. Pre-push gitleaks hook (`make install-hooks`) and CI enforce this; docs/tests use obviously-fake placeholders.
+- **Secret-safe telemetry**: no payload data in logs/events/conditions/metrics — hashes only. The AST audit test enforces it; don't fight the ratchet.
+- **Commit trailer**: end commits with `Co-Authored-By: Claude <model name> <noreply@anthropic.com>` — deliberate AI-transparency policy for this repo.
+- Webhook stays `failurePolicy: Ignore`; policy enforcement stays reconcile-time authoritative (design D6).
+- `config/webhook/manifests.yaml` is hand-maintained (controller-gen can't express matchConditions) — keep in sync with `internal/webhook`.
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/Makefile
+++ b/Makefile
@@ -257,3 +257,13 @@ fleet-down: ## Delete all local kind fleet clusters.
 .PHONY: fleet-kubeconfigs
 fleet-kubeconfigs: ## Export per-cluster kubeconfigs to ./bin/kubeconfigs/.
 	hack/kind-fleet.sh kubeconfigs
+
+##@ Git Hooks & Docs Sync
+
+.PHONY: install-hooks
+install-hooks: ## Install git hooks: pre-push gitleaks scan, post-commit graphify rebuild.
+	bash hack/install-git-hooks.sh
+
+.PHONY: secret-scan
+secret-scan: ## Scan the full git history for leaked secrets with gitleaks.
+	gitleaks git --no-banner --redact .

--- a/hack/git-hooks/pre-push
+++ b/hack/git-hooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# pre-push hook: scan outgoing commits for secrets with gitleaks.
+# Installed by `make install-hooks` (hack/install-git-hooks.sh).
+# k8s-r8r is a public repository — nothing sensitive may leave this machine.
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "pre-push: gitleaks not found — install it (brew install gitleaks) or bypass ONCE with --no-verify" >&2
+  exit 1
+fi
+
+zero=0000000000000000000000000000000000000000
+status=0
+
+# stdin: <local ref> <local sha> <remote ref> <remote sha>
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+  [ "$local_sha" = "$zero" ] && continue # deleting a remote ref — nothing to scan
+  if [ "$remote_sha" = "$zero" ]; then
+    range="$local_sha" # new branch: scan the pushed history
+    log_opts="$range --not --remotes=origin"
+  else
+    log_opts="$remote_sha..$local_sha"
+  fi
+  if ! gitleaks git --log-opts="$log_opts" --no-banner --redact .; then
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "" >&2
+  echo "pre-push: gitleaks found potential secrets in outgoing commits — push blocked." >&2
+  echo "Remove the secret from history (rebase/amend), or allowlist a false positive in .gitleaks.toml." >&2
+fi
+exit "$status"

--- a/hack/install-git-hooks.sh
+++ b/hack/install-git-hooks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Install k8s-r8r git hooks into .git/hooks:
+#   pre-push    — gitleaks secret scan (public repo gate)
+#   post-commit — graphify knowledge-graph incremental rebuild (if graphify is installed)
+# Usage: make install-hooks   (or: bash hack/install-git-hooks.sh)
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+hooks_dir="$repo_root/.git/hooks"
+
+install -m 0755 "$repo_root/hack/git-hooks/pre-push" "$hooks_dir/pre-push"
+echo "installed: pre-push (gitleaks)"
+
+if command -v graphify >/dev/null 2>&1; then
+  (cd "$repo_root" && graphify hook install) && echo "installed: post-commit (graphify)"
+else
+  echo "skipped: graphify post-commit hook (graphify not installed)"
+fi
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "WARNING: gitleaks not installed — pre-push hook will refuse pushes until it is (brew install gitleaks)"
+fi

--- a/obsidian/architecture.md
+++ b/obsidian/architecture.md
@@ -1,0 +1,43 @@
+---
+tags: [architecture]
+---
+
+# Architecture
+
+Hub-spoke, push-based. Everything runs on the hub; spokes only receive replicas via narrowly-scoped ServiceAccounts.
+
+```
+                     HUB CLUSTER
+ annotated Secret ──▶ request controller ──▶ Replication (canonical CR)
+                                                  │ gated by
+                                          ReplicationPolicy (default deny)
+                                                  │
+        Discovery (CAPI) ──▶ cluster runtimes ──▶ push Transport
+             │                    (1 per ready cluster)
+             └─ kubeconfig ──▶ SA bootstrap (once) ──▶ token rotation
+                                                  │
+                                     spokes: replicas + metadata-only watches
+```
+
+## Design principle
+
+**Interfaces and data model final from day one; feature surface narrow.** Generic-GVK pipeline exists internally (allowlist gates it to Secrets/ConfigMaps); `Transport` and `Discovery` are interfaces with one implementation each; the canonical [[replication-flow|Replication layer]] admits future request origins (`ReplicationSet`).
+
+## Design decisions (openspec design.md)
+
+| # | Decision | Why (short) |
+|---|---|---|
+| D1 | Annotation shim over canonical CRD | cert-manager pattern; status+inventory need a home |
+| D2 | Push transport first | CAPI gives creds free; pull agent later slot |
+| D3 | Metadata-only drift watches | no secret data cached on hub — see [[drift-detection]] |
+| D4 | Default deny, union, allowlists only | deny-precedence kills policy engines — see [[policy-model]] |
+| D5 | Narrow spoke SA bootstrap | blast radius; retrofit never happens — see [[security-model]] |
+| D6 | Webhook advisory, controller authoritative | `failurePolicy: Fail` would block secret writes |
+| D7 | Conflicts Fail/Overwrite/Adopt, no auto-rename | silent rename breaks name-based consumers |
+| D8 | Capped status | etcd 1.5MB limit, no churn — see [[operations]] |
+| D9 | Workqueue keyed (source, targetCluster) | slow cluster never blocks fanout; sharding-ready |
+| D10 | kubebuilder + controller-runtime, `r8r.io/v1alpha1` | ecosystem standard |
+
+## Packages
+
+`api/v1alpha1` (CRDs) · `internal/annotations` (contract parser) · `internal/policy` (evaluation) · `internal/discovery` + `internal/discovery/capi` · `internal/cluster` (bootstrap, tokens, runtimes) · `internal/controller/request` (shim) · `internal/engine` (fanout/drift/GC) · `internal/webhook` · `internal/telemetry` · `cmd/main.go` (wiring). Full symbol-level map: `graph/graph.canvas`.

--- a/obsidian/cluster-discovery.md
+++ b/obsidian/cluster-discovery.md
@@ -1,0 +1,32 @@
+---
+tags: [functionality]
+---
+
+# Cluster Discovery
+
+Pluggable provider interface turns fleet-management systems into replication target inventory. A provider emits `ClusterRecord`s (stable name, labels, readiness, credential ref) plus register/update/deregister events. Adding Fleet/Rancher/static providers later touches nothing else.
+
+## ClusterAPI provider (v1)
+
+`internal/discovery/capi` watches `cluster.x-k8s.io/v1beta1 Cluster` objects **unstructured** (no CAPI module dependency — keeps go.mod lean, decouples from CAPI's k8s version pins):
+- selection labels = the `Cluster` object's labels (used by [[replication-flow|`r8r.io/target-clusters`]] and [[policy-model|policy `clusterSelector`]])
+- targetable only when control plane ready (`ControlPlaneReady` v1beta1 / `ControlPlaneAvailable` v1beta2)
+- credentials from the conventional `<cluster>-kubeconfig` Secret
+
+## Credential bootstrap (D5)
+
+The CAPI kubeconfig is cluster-admin — never used for steady-state traffic. On registration, once:
+
+```
+admin kubeconfig ──▶ create on spoke: ns k8s-r8r-system, SA k8s-r8r,
+                     narrow ClusterRole (only kinds/verbs the policy universe needs)
+                └──▶ then: short-lived SA tokens (TokenRequest, refresh at 80% TTL)
+```
+
+Hub compromise blast radius drops from "fleet admin" to "write allowlisted kinds". RBAC re-narrows when the policy universe shrinks. Details: [[security-model]].
+
+## Cluster runtimes
+
+`internal/cluster.Manager` keeps exactly one runtime (client + cache) per ready cluster: started on register, stopped+drained on deregister. Connectivity tracked per cluster (`Reachable | Degraded | Unreachable{Since}`) with independent backoff — one dead spoke never blocks the rest. Runtimes carry the metadata-only caches used by [[drift-detection]]. Deregistration → inventory released with `ClusterGone` (see [[replication-flow]]).
+
+Spec: `openspec/specs/cluster-discovery`

--- a/obsidian/development.md
+++ b/obsidian/development.md
@@ -1,0 +1,35 @@
+---
+tags: [development, workflow]
+---
+
+# Development
+
+## Layout
+
+kubebuilder project, module `github.com/moeritze/k8s-r8r`, API group `r8r.io/v1alpha1`. Package map: [[architecture]].
+
+## Testing ladder
+
+1. **Unit + envtest** — `make test` (207 tests; engine/request suites run against an envtest API server, spokes faked via recording Transport)
+2. **e2e** — `make test-e2e`: provisions a real kind fleet (`hack/kind-fleet.sh`, hub + 2 spokes), simulates ClusterAPI with a minimal CRD + status-patched `Cluster` objects + `--internal` kubeconfig Secrets, exercises full [[replication-flow]], [[cluster-discovery|cluster lifecycle]], and scale. `K8S_R8R_E2E_KEEP=1` keeps the fleet for debugging.
+3. **CI** (`.github/workflows/ci.yml`) — lint (custom golangci-lint w/ logcheck), test, build, e2e. Lint runs the same binary locally via `make lint`.
+
+## Documentation workflow (keep in sync — part of every change)
+
+Three layers, updated together:
+
+1. **openspec** (`../openspec/`) — behavior source of truth. New work = `openspec new change`, artifacts per `/opsx:*` flow; specs updated when behavior changes.
+2. **This vault** (`obsidian/`) — curated functionality notes ([[k8s-r8r|hub]]). Update the affected note in the same session as the code change.
+3. **Knowledge graph** (`graph/` + `graphify-out/`) — regenerate incrementally with `/graphify --update` (or the post-commit hook for code changes); re-export with `graphify export obsidian --dir obsidian/graph`.
+
+Guardrail: repo `CLAUDE.md` codifies this for agent sessions.
+
+## Secret hygiene (public repo)
+
+- `make install-hooks` installs the **gitleaks pre-push hook** — every push scanned; CI runs gitleaks too ([[security-model]])
+- exported kubeconfigs (`bin/`), `.remember/`, graph build artifacts (`graphify-out/`) are gitignored
+- example values in docs: obviously fake only
+
+## Conventions
+
+Conventional commits; Claude co-authorship trailer is deliberate policy (AI-usage transparency for contributors). DCO/CONTRIBUTING: planned post-v1.

--- a/obsidian/drift-detection.md
+++ b/obsidian/drift-detection.md
@@ -1,0 +1,28 @@
+---
+tags: [functionality]
+---
+
+# Drift Detection
+
+Replicas converge event-driven, and the hub never caches spoke secret payloads.
+
+## Mechanism (D3)
+
+Per (cluster, replicated GVK) the engine runs a **metadata-only informer** (`PartialObjectMetadata`) on the [[cluster-discovery|cluster runtime]]'s cache, label-filtered to `app.kubernetes.io/managed-by: k8s-r8r` (server-side via cache `DefaultLabelSelector`):
+
+```
+watch event ──▶ compare r8r.io/source-hash annotation vs desired
+   mismatch or deletion ──▶ enqueue owning Replication (via source-ref labels)
+        reconcile ──▶ live-read replica, restore from source
+```
+
+- Hash = sha256 of canonical payload after stripping server-managed/identity fields; source, replica, and renamed replica hash identically.
+- Payload-only edits that don't touch metadata still repair: every managed-object event enqueues, and reconcile compares live content.
+- Fallback resync (default 10h, `--spoke-resync`) catches missed events and dropped watches.
+- Informer lifecycle bound to cluster register/deregister.
+
+## Why metadata-only
+
+Memory stays bounded at fleet scale AND no fleet-wide secret data accumulates in hub caches — scale and [[security-model|security]] in one move. Cost: one watch connection per cluster per GVK (ArgoCD-proven pattern).
+
+Implementation: `internal/engine/drift.go` · spec: `openspec/specs/replication-engine` (drift requirement) · flow context: [[replication-flow]]

--- a/obsidian/history/original-brainstorm.md
+++ b/obsidian/history/original-brainstorm.md
@@ -1,0 +1,23 @@
+- the application stands for kubernetes-replicator
+- "declarative fanout of k8s objects (mainly for secrets, that is my use case) across a kubernetes fleet, with pluggable cluster discovery"
+- the idea is to build an open source software tool, which can replicate k8s objects across the cluster
+	- here we should brainstorm and research what is useful and secure in terms of rbac
+	- also how we could build conditioning and restrictions
+	- annotations on k8s manifests make target decisions for the replications
+	- a rule set or map should decide if thats allowed or not
+	- focus on working really good with gitops argocd
+	- this should also work cross cluster with clusterapi first, as clusters can be registered as clusterapi k8s objects, with dedicated annotations here
+		- later on also with rancher/fleet/aks,eks,gke and whatever multi cluster approach might fit
+- the application should be build in Go
+- thoughts
+	- replicas should be tracked, so they are not orphaned
+	- workqueue
+	- well documented
+	- work with openspec and claude
+	- ensuring a ns exists
+	- test & CI
+	- controller runtime
+	- CRDs as primary API
+	- leader election
+	- metrics/events
+	- 

--- a/obsidian/k8s-r8r.md
+++ b/obsidian/k8s-r8r.md
@@ -1,23 +1,32 @@
-- the application stands for kubernetes-replicator
-- "declarative fanout of k8s objects (mainly for secrets, that is my use case) across a kubernetes fleet, with pluggable cluster discovery"
-- the idea is to build an open source software tool, which can replicate k8s objects across the cluster
-	- here we should brainstorm and research what is useful and secure in terms of rbac
-	- also how we could build conditioning and restrictions
-	- annotations on k8s manifests make target decisions for the replications
-	- a rule set or map should decide if thats allowed or not
-	- focus on working really good with gitops argocd
-	- this should also work cross cluster with clusterapi first, as clusters can be registered as clusterapi k8s objects, with dedicated annotations here
-		- later on also with rancher/fleet/aks,eks,gke and whatever multi cluster approach might fit
-- the application should be build in Go
-- thoughts
-	- replicas should be tracked, so they are not orphaned
-	- workqueue
-	- well documented
-	- work with openspec and claude
-	- ensuring a ns exists
-	- test & CI
-	- controller runtime
-	- CRDs as primary API
-	- leader election
-	- metrics/events
-	- 
+---
+tags: [hub]
+aliases: [kubernetes-replicator, home]
+---
+
+# k8s-r8r
+
+Declarative fanout of Kubernetes objects (Secrets, ConfigMaps) across a fleet — annotation-driven, policy-gated, with pluggable cluster discovery (ClusterAPI first). Built in Go on controller-runtime. Public repo: [github.com/moeritze/k8s-r8r](https://github.com/moeritze/k8s-r8r).
+
+> One annotation on a Secret + one admin policy = replicas on every selected cluster, tracked, drift-repaired, garbage-collected.
+
+## Functionality
+
+- [[replication-flow]] — the core path: annotation → `Replication` object → engine → replicas on spokes
+- [[policy-model]] — default-deny `ReplicationPolicy` gating: who may replicate what, where
+- [[cluster-discovery]] — how the fleet is discovered (ClusterAPI) and spoke credentials are bootstrapped
+- [[drift-detection]] — how replicas stay in sync without the hub caching secret data
+- [[security-model]] — threat model, RBAC personas, advisory webhook doctrine
+- [[operations]] — metrics, events, HA, status size discipline
+- [[architecture]] — component map and design decisions D1–D10
+- [[development]] — repo layout, testing (envtest + kind e2e), tooling workflow
+
+## Deep reference
+
+- `graph/` — auto-generated knowledge graph of the whole codebase (open `graph/graph.canvas`, regenerate per [[development]])
+- `../docs/` — user-facing docs (quickstart, annotations, policies, gitops, security, uninstall)
+- `../openspec/` — requirement specs + change history (source of truth for behavior)
+- [[history/original-brainstorm]] — where this started
+
+## Status
+
+v0 alpha (2026-08). Bootstrap change `bootstrap-k8s-r8r-operator`: 36/36 tasks, unit+envtest 207 tests, e2e green on kind fleet. Post-v1 topics: licensing model, contribution setup, distribution.

--- a/obsidian/operations.md
+++ b/obsidian/operations.md
@@ -1,0 +1,27 @@
+---
+tags: [functionality, operations]
+---
+
+# Operations
+
+## Metrics (`internal/telemetry`, prefix `k8s_r8r_`)
+
+Replica desired/ready/failed gauges (per cluster) · policy/webhook denial counters (per dimension) · conflict, revocation, drift counters · cluster connectivity gauge (0 unreachable / 1 degraded / 2 reachable) · bootstrap + token rotation counters. Reconcile durations/workqueue depth come from controller-runtime built-ins. Cardinality bounded by test: labels only cluster/namespace/kind — never object names.
+
+## Events
+
+Lifecycle transitions on sources and Replications (Replicated, PolicyDenied, Conflict, PolicyRevoked, ClusterGone, CleanedUp), rate-limited per object+reason (5m cooldown, changed messages pass) so flapping targets can't flood. [[security-model|Never any payload data]].
+
+## Status discipline (D8)
+
+Summary counts + `Ready` condition; per-target detail only for non-ready targets, capped at 20 + overflow counter; status writes skipped when unchanged. 60-target e2e fanout: 13.9KB status, zero churn over 2 minutes. Full per-target truth lives in metrics/events.
+
+## HA
+
+Leader election (single writer, standby failover from persisted CRs/inventory). Readiness = hub informers synced only — a dead spoke can structurally never flip readiness ([[cluster-discovery|per-cluster runtimes]] isolate outages). Deployment hardened per restricted PSS; Helm chart supports `replicaCount > 1`.
+
+## Install / uninstall
+
+Helm chart `charts/k8s-r8r` (webhook cert-manager toggle, personas, metrics). Teardown order matters: remove annotations/policies → replicas GC → `helm uninstall`; finalizer escape hatch documented in `../docs/uninstall.md`.
+
+Spec: `openspec/specs/observability-operations`

--- a/obsidian/policy-model.md
+++ b/obsidian/policy-model.md
@@ -1,0 +1,35 @@
+---
+tags: [functionality, security]
+---
+
+# Policy Model
+
+`ReplicationPolicy` (cluster-scoped, admin-only) is the security boundary. **Default deny**: no policies → nothing replicates, ever.
+
+## Semantics
+
+- **Allowlists only** — no deny rules; denying = not allowing.
+- **All dimensions, one policy**: a target is permitted only if a *single* policy matches source namespace, source kind, target cluster (labels), and target namespace. Dimensions never combine across policies.
+- **Union across policies**: any one fully-matching policy suffices.
+- Policy-side empty `clusterSelector` matches *all* clusters; request-side empty selector matches *none* (requests must be explicit, policies may be broad). Invalid selectors fail closed.
+
+```yaml
+apiVersion: r8r.io/v1alpha1
+kind: ReplicationPolicy
+spec:
+  sources: {namespaces: ["platform"], kinds: [Secret]}
+  targets: {clusterSelector: {matchLabels: {env: prod}}, namespaces: [istio-system]}
+  options: {allowNamespaceCreation: false, allowedConflictPolicies: [Fail], revocationPolicy: Delete}
+```
+
+## Options (union when several policies permit)
+
+- `allowNamespaceCreation` — OR
+- `allowedConflictPolicies` — union, `Fail` always included; engine acts with the strongest granted (`Overwrite > Adopt > Fail`)
+- `revocationPolicy` — most conservative wins (`Retain` beats `Delete`)
+
+## Revocation
+
+Policy is re-evaluated on **every** reconcile — reconcile-time enforcement is authoritative, the [[security-model|webhook]] is advisory only. Tightening a policy revokes live: `Delete` removes replicas; `Retain` freezes them with `PolicyRevoked`. No grandfathering.
+
+Implementation: `internal/policy` (pure functions: `Evaluate`, `ResolveOptions`, `DetectRevocations`). Consumed by [[replication-flow|request controller + engine]]. Spec: `openspec/specs/replication-policy` · guide: `../docs/policies.md`

--- a/obsidian/replication-flow.md
+++ b/obsidian/replication-flow.md
@@ -1,0 +1,40 @@
+---
+tags: [functionality]
+---
+
+# Replication Flow
+
+The core path from developer intent to replicas on the fleet.
+
+## 1. Request (developer)
+
+Annotate any allowlisted object (Secret, ConfigMap):
+
+```yaml
+metadata:
+  annotations:
+    r8r.io/replicate: "true"
+    r8r.io/target-clusters: "env=prod"        # label selector over cluster inventory; empty = NO clusters, no wildcard
+    r8r.io/target-namespaces: "istio-system"  # default: source namespace
+    r8r.io/target-name: "ca-cert"             # optional explicit rename — never automatic
+```
+
+Parsed by `internal/annotations` (shared with the [[security-model|webhook]]). Devs need zero new RBAC — you can only fan out what you can already write.
+
+## 2. Materialization (request controller)
+
+`internal/controller/request` resolves selector × [[cluster-discovery|discovered inventory]] × [[policy-model|policy verdict]] into one operator-owned **`Replication`** object per source (origin `Annotation`, designed to admit a future `ReplicationSet`). Hand-authored Replications get `NotAuthoritative` and are ignored. Finalizer `r8r.io/finalizer` on the source blocks its deletion until replica cleanup completes.
+
+## 3. Fanout (engine)
+
+`internal/engine` reconciles each `Replication` per target (workqueue key = source + targetCluster; independent backoff):
+- payload stripped of server-managed fields, stamped with `app.kubernetes.io/managed-by: k8s-r8r`, source-ref labels, `r8r.io/source-hash: sha256:…`
+- applied via server-side apply (field manager `k8s-r8r`) over the push `Transport` using the spoke's [[security-model|bootstrapped SA token]]
+- conflicts with pre-existing unmanaged objects: `Fail` (default) / `Overwrite` (policy-gated) / `Adopt` (hash-equal only)
+- missing namespace: created only when policy sets `allowNamespaceCreation`; namespaces are never GC'd
+
+## 4. Tracking and cleanup
+
+Every replica lands in `Replication.status.inventory` — the GC source of truth. Cleanup triggers: source deleted, annotation removed, target deselected, policy revoked ([[policy-model#revocation|revocation]]). Cluster deregistration releases inventory with a `ClusterGone` event (no credential remains to delete with) — deselect before deregistering for clean removal. Ongoing sync: [[drift-detection]].
+
+Spec: `openspec/specs` (`replication-request`, `replication-engine`) · user docs: `../docs/annotations.md`

--- a/obsidian/security-model.md
+++ b/obsidian/security-model.md
@@ -1,0 +1,35 @@
+---
+tags: [functionality, security]
+---
+
+# Security Model
+
+Full write-up: `../docs/security.md`. Core stances:
+
+## Personas (RBAC)
+
+| Persona | Power | Vehicle |
+|---|---|---|
+| Platform admin | author `ReplicationPolicy` | `k8s-r8r-policy-admin` ClusterRole, never auto-bound |
+| Developer | annotate objects they already own | **zero new privileges** — [[policy-model]] gates destinations |
+| Operator SA | read allowlisted kinds, CAPI clusters + kubeconfig Secrets (crown jewels), own Replications | manager ClusterRole |
+| User (read) | view Replications | `k8s-r8r-replication-viewer`, aggregates to `view` |
+
+## Push architecture + blast radius (D2/D5)
+
+Hub holds fleet write access → mitigated by [[cluster-discovery#credential-bootstrap-d5|one-shot narrow SA bootstrap]]: admin kubeconfig used once, steady state runs on short-lived rotated SA tokens scoped to allowlisted kinds. Pull-agent transport is a future `Transport` implementation.
+
+## Advisory webhook doctrine (D6)
+
+Validating webhook (CEL matchConditions: fires only on objects carrying `r8r.io/` annotations; K8s ≥ 1.30) gives apply-time errors naming the failing policy dimension. `failurePolicy: Ignore` is **mandatory** — `Fail` would let operator downtime block all annotated secret writes. Security never depends on it: reconcile-time policy evaluation is authoritative; a bypassed webhook means worse error messages, never unauthorized replication.
+
+## Secret-safe telemetry
+
+No log, event, condition, or metric ever contains payload data — hashes only. Enforced twice: runtime canary test + AST-walking static ratchet (`internal/telemetry/secretsafety_audit_test.go`) that fails on any `Data`/`StringData` reaching a formatting/event call. Checklist: `internal/telemetry/REVIEW_CHECKLIST.md`.
+
+## Weaponization guards
+
+- `Overwrite` conflict mode could replace a victim cluster's secret → policy-gated, `Fail` default; replicas of a *different* source are never taken over ([[replication-flow]]).
+- Exfiltration via annotation → blocked by default-deny [[policy-model]]; no request-side override exists.
+
+Repo hygiene: public repo — gitleaks pre-push hook + CI job gate every push (see [[development]]).


### PR DESCRIPTION
## What

Follow-up to #the bootstrap PR (feat/bootstrap-operator). Three concerns:

### 1. Obsidian documentation vault (`obsidian/`)
- Hub note `k8s-r8r.md` + 8 curated functionality notes (replication flow, policy model, cluster discovery, drift detection, security model, operations, architecture, development), cross-linked with wikilinks
- Original brainstorm preserved under `history/`
- Auto-generated knowledge-graph vault (`obsidian/graph/`, 1121 notes, 4.7MB) is **gitignored** — regenerable via `graphify export obsidian --dir obsidian/graph`. Flip the gitignore entry if you'd rather commit it.

### 2. Secret-scanning guardrails (public repo)
- `.gitleaks.toml` + pre-push git hook (`make install-hooks`) — blocks pushes containing secrets
- `make secret-scan` for full-history scans (current history: clean, 21 commits)
- CI job `secret-scan` (gitleaks-action, full history) gating every push/PR

### 3. Docs/spec sync automation
- Repo `CLAUDE.md`: workflow contract — every change flows openspec → code → obsidian notes → graphify update; docs are part of done
- graphify post-commit hook (auto graph rebuild on code commits) via the hook installer
- `.claude/settings.json`: graph-first code exploration hooks for agent sessions

## Notes
- Draft until `feat/bootstrap-operator` merges (branch is based on its head; diff then reduces to the 18 docs/guardrail files)
- Hooks are opt-in per clone (`make install-hooks`); CI enforces scanning regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)