### PR TITLE
docs: community files for public OSS collaboration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @moeritze

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Something is broken in k8s-r8r
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+        **Security vulnerabilities**: do NOT report them here — see [SECURITY.md](https://github.com/moeritze/k8s-r8r/blob/main/SECURITY.md).
+  - type: input
+    id: version
+    attributes:
+      label: k8s-r8r version / commit
+      description: Release tag or git commit SHA of the operator you are running.
+      placeholder: v0.3.0 / 1a2b3c4
+    validations:
+      required: true
+  - type: input
+    id: hub-k8s-version
+    attributes:
+      label: Hub Kubernetes version
+      placeholder: v1.31.2 (kind / EKS / ...)
+    validations:
+      required: true
+  - type: input
+    id: spoke-k8s-versions
+    attributes:
+      label: Spoke Kubernetes version(s)
+      description: Versions of the spoke clusters involved (comma-separated if mixed).
+      placeholder: v1.30.4, v1.31.2
+    validations:
+      required: false
+  - type: input
+    id: discovery-provider
+    attributes:
+      label: Discovery provider
+      description: How your spoke clusters are discovered.
+      placeholder: static / kubeconfig-secrets / ...
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What actually happened, and what did you expect instead?
+      placeholder: |
+        What happened:
+        ...
+
+        What I expected:
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: status-and-events
+    attributes:
+      label: Relevant Replication status and events
+      description: |
+        Output of `kubectl get replication <name> -o yaml` (status section) and `kubectl describe` events for the affected objects.
+
+        **NEVER paste secret data.** Redact anything sensitive — this is a public repo. k8s-r8r itself never logs payload data (hashes only), but double-check anything you copy from your cluster before posting.
+      render: yaml
+    validations:
+      required: false
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce the behavior. Manifests with obviously-fake placeholder data are very helpful.
+      placeholder: |
+        1. Create a ReplicationPolicy that ...
+        2. Annotate the Secret with ...
+        3. Observe ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/moeritze/k8s-r8r/blob/main/SECURITY.md
+    about: Do NOT open a public issue for vulnerabilities — use GitHub private vulnerability reporting as described in SECURITY.md.
+  - name: Questions & discussion
+    url: https://github.com/moeritze/k8s-r8r/discussions
+    about: Ask questions, share ideas, or discuss usage in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest an idea or improvement for k8s-r8r
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Note that behavior changes go through [OpenSpec](https://github.com/moeritze/k8s-r8r/blob/main/CONTRIBUTING.md#workflow) — a maintainer will help turn an accepted request into a spec change.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? What is currently not possible or painful?
+      placeholder: I want to replicate ... but ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work? API/annotation/policy sketches welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you have considered or tried.
+    validations:
+      required: false
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Willingness to contribute
+      description: Would you be willing to implement this (with guidance)?
+      options:
+        - Yes, I can implement it
+        - Yes, with some guidance
+        - No, but I can test it
+        - "No"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What does this PR do and why? Link the OpenSpec change if one exists. -->
+
+## Checklist
+
+- [ ] **Spec**: behavior change went through [OpenSpec](../openspec/) (spec delta agreed before implementation), or this is a small fix that doesn't touch the replication/policy/discovery contracts
+- [ ] **Tests**: new behavior has unit coverage; engine/discovery/transport changes have e2e coverage
+- [ ] **Docs**: affected `obsidian/` note and relevant `docs/*.md` updated in this PR
+- [ ] **Lint & tests green**: `make lint && make test` pass locally
+- [ ] **No sensitive data**: nothing secret in code, tests, docs, or fixtures — placeholders are obviously fake; no payload data in logs/events/conditions/metrics (hashes only)
+- [ ] **AI disclosure**: substantial AI assistance is disclosed (`Co-Authored-By` trailer or note below), per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-usage-disclosure)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by contacting the
+maintainer ([@moeritze](https://github.com/moeritze)) privately via GitHub
+(direct message or [report abuse](https://github.com/contact/report-abuse)).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to k8s-r8r
+
+Thanks for your interest! k8s-r8r replicates Kubernetes objects across fleets — annotation-driven, policy-gated. Before contributing, skim the [README](README.md) and the documentation hub at [`obsidian/k8s-r8r.md`](obsidian/k8s-r8r.md).
+
+## Development setup
+
+```bash
+git clone https://github.com/moeritze/k8s-r8r && cd k8s-r8r
+make install-hooks   # REQUIRED: installs the gitleaks pre-push secret scan
+make test            # unit + envtest
+make test-e2e        # full e2e on a local kind fleet (needs docker + kind)
+```
+
+Toolchain: Go (see `go.mod`), docker, kind, helm, gitleaks. `hack/kind-fleet.sh` manages a local hub + spokes fleet.
+
+## Workflow
+
+1. **Specs first**: behavior changes go through [OpenSpec](openspec/) — propose a change (`openspec new change`), get the spec delta agreed, then implement. Small fixes can skip this; anything touching the replication/policy/discovery contracts cannot.
+2. **Tests are the contract**: every spec scenario maps to a test. New behavior needs unit coverage; engine/discovery/transport changes need e2e coverage.
+3. **Docs are part of done**: update the affected note in `obsidian/` and the relevant `docs/*.md` in the same PR.
+4. **Lint**: `make lint` (builds the repo's custom golangci-lint — CI runs the identical binary).
+
+## Hard rules
+
+- **Never commit sensitive data.** Public repo. The pre-push hook and CI gitleaks job will block you; don't fight them. Docs/tests use obviously-fake placeholders.
+- **Secret-safe telemetry**: no payload data in logs/events/conditions/metrics — hashes only. An AST audit test enforces this.
+- The admission webhook stays `failurePolicy: Ignore`; policy enforcement stays reconcile-time authoritative (see `docs/security.md`).
+
+## AI usage disclosure
+
+This project is developed with substantial AI assistance (Claude). We are transparent about it: AI-assisted commits carry a `Co-Authored-By: Claude ...` trailer. Contributors are welcome to use AI tools; you remain fully responsible for what you submit — review it, test it, understand it. Disclose substantial AI assistance the same way (co-author trailer or PR note).
+
+## Pull requests
+
+- Branch from `main`, conventional-commit style messages (`feat:`, `fix:`, `docs:`, …)
+- CI must be green (lint, tests, build, e2e, secret scan)
+- Keep PRs focused; link the OpenSpec change if one exists
+
+## Reporting issues
+
+Use the issue templates. For security vulnerabilities, see [SECURITY.md](SECURITY.md) — do **not** open a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+k8s-r8r handles Secrets across cluster fleets — security reports are taken seriously.
+
+## Reporting a vulnerability
+
+**Do not open a public issue.** Use [GitHub private vulnerability reporting](https://github.com/moeritze/k8s-r8r/security/advisories/new) (Security → Report a vulnerability).
+
+You can expect an acknowledgment within a few days. Please include: affected version/commit, reproduction steps, and impact assessment if you have one.
+
+## Scope of interest
+
+Particularly relevant given the threat model (see [docs/security.md](docs/security.md)):
+
+- Policy bypass: any way a replication request reaches a destination no `ReplicationPolicy` allows
+- Privilege escalation via the operator (hub or spoke ServiceAccounts)
+- Secret data leaking into logs, events, conditions, or metrics
+- Webhook-related bypasses that violate the documented advisory-only doctrine
+- Replica takeover of objects k8s-r8r does not manage (conflict-handling bypasses)
+
+## Supported versions
+
+Pre-1.0: only the latest release / `main` receives fixes.


### PR DESCRIPTION
## Summary

Community-files bundle for public OSS collaboration:

- **CONTRIBUTING.md** — dev setup, spec-first workflow (OpenSpec), hard rules (no sensitive data, secret-safe telemetry), AI usage disclosure policy, PR conventions
- **SECURITY.md** — private vulnerability reporting via GitHub security advisories, scope of interest, supported versions
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1; contact: private GitHub report to the maintainer (@moeritze)
- **.github/ISSUE_TEMPLATE/bug_report.yml** — versions (operator/hub/spokes), discovery provider, expected vs actual, Replication status + events (with redaction reminder — never paste secret data), repro steps
- **.github/ISSUE_TEMPLATE/feature_request.yml** — problem, proposed solution, alternatives, willingness to contribute
- **.github/ISSUE_TEMPLATE/config.yml** — blank issues disabled; contact links to SECURITY.md and GitHub Discussions
- **.github/pull_request_template.md** — checklist mirroring CONTRIBUTING.md (spec, tests, docs, lint/test green, no sensitive data, AI disclosure)
- **.github/CODEOWNERS** — `* @moeritze`

## Status

Draft until `feat/bootstrap-operator` merges to `main` — this branch is based on its head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)