### PR TITLE
chore: adopt DCO (Apache-2.0 + DCO, no CLA)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,34 @@ on:
 permissions: {}
 
 jobs:
+  dco:
+    name: DCO
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Check Signed-off-by on all PR commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          # Merge commits are exempt (GitHub's own update-branch merges carry no sign-off).
+          for sha in $(git rev-list --no-merges "$BASE_SHA".."$HEAD_SHA"); do
+            if ! git log -1 --format=%B "$sha" | grep -qi '^Signed-off-by: .\+<.\+@.\+>'; then
+              echo "::error::commit $sha lacks a Signed-off-by trailer (use 'git commit -s')"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] && echo "All commits signed off."
+          exit "$missing"
+
   secret-scan:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,16 @@ Toolchain: Go (see `go.mod`), docker, kind, helm, gitleaks. `hack/kind-fleet.sh`
 - **Secret-safe telemetry**: no payload data in logs/events/conditions/metrics — hashes only. An AST audit test enforces this.
 - The admission webhook stays `failurePolicy: Ignore`; policy enforcement stays reconcile-time authoritative (see `docs/security.md`).
 
+## Developer Certificate of Origin (DCO)
+
+This project uses the [Developer Certificate of Origin](https://developercertificate.org/) instead of a CLA. Every commit must carry a `Signed-off-by` trailer certifying you have the right to submit the change under Apache-2.0:
+
+```bash
+git commit -s   # adds: Signed-off-by: Your Name <you@example.com>
+```
+
+Forgot it? `git commit --amend -s` (single commit) or `git rebase --signoff main` (a branch). The CI `DCO` check blocks PRs containing unsigned commits (merge commits are exempt).
+
 ## AI usage disclosure
 
 This project is developed with substantial AI assistance (Claude). We are transparent about it: AI-assisted commits carry a `Co-Authored-By: Claude ...` trailer. Contributors are welcome to use AI tools; you remain fully responsible for what you submit — review it, test it, understand it. Disclose substantial AI assistance the same way (co-author trailer or PR note).


### PR DESCRIPTION
Implements the decided licensing model: Apache-2.0 (existing) + Developer Certificate of Origin.

- CONTRIBUTING.md: DCO section — `git commit -s`, fix-up commands, developercertificate.org link
- CI: new `DCO` job validating `Signed-off-by` on all non-merge PR commits (merge commits exempt, matching the DCO app's behavior)
- Follow-up after merge: `DCO` added to required status checks; optionally install the official DCO GitHub App as redundancy (maintainer-only action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)