### PR TITLE
feat: add tag-triggered release publishing (image + chart + GitHub release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Release
+
+# Publishes release artifacts when a version tag (v*) is pushed:
+#   - multi-arch operator image  -> ghcr.io/moeritze/k8s-r8r:<tag> (+ :latest for stable tags)
+#   - packaged Helm chart        -> oci://ghcr.io/moeritze/charts/k8s-r8r
+#   - GitHub release with generated notes (prerelease when the tag contains '-')
+# See docs/releasing.md.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions: {}
+
+jobs:
+  publish-image:
+    name: Publish container image (ghcr)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          tags="ghcr.io/moeritze/k8s-r8r:${TAG}"
+          # Stable semver only (no '-'): also move :latest.
+          case "$TAG" in
+            *-*) echo "prerelease tag — skipping :latest" ;;
+            *)   tags="${tags},ghcr.io/moeritze/k8s-r8r:latest" ;;
+          esac
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push (linux/amd64, linux/arm64)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+
+  publish-chart:
+    name: Publish Helm chart (ghcr OCI)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Package and push chart
+        env:
+          TAG: ${{ github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          echo "${GITHUB_TOKEN}" | helm registry login ghcr.io \
+            --username "${GITHUB_ACTOR}" --password-stdin
+          # Chart version tracks the tag (without v); appVersion is the full
+          # tag so the chart's default image tag (.Chart.AppVersion) resolves
+          # to the image published by this same run.
+          helm package charts/k8s-r8r \
+            --version "${version}" \
+            --app-version "${TAG}"
+          helm push "k8s-r8r-${version}.tgz" oci://ghcr.io/moeritze/charts
+
+  github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - publish-image
+      - publish-chart
+    permissions:
+      contents: write
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Create release with generated notes
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          args=(--generate-notes --verify-tag)
+          # Tags containing '-' (e.g. v0.2.0-alpha.1) are prereleases.
+          case "$TAG" in
+            *-*) args+=(--prerelease) ;;
+          esac
+          gh release create "$TAG" "${args[@]}" \
+            --title "$TAG" \
+            --repo "$GITHUB_REPOSITORY"

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ That's the whole developer API. An admin-owned, default-deny
 data model are designed not to change); the feature surface ships narrow.
 Unit and envtest coverage exists across the controllers, policy engine,
 and webhook; **the cross-cluster path is not yet exercised by an
-end-to-end suite**, and no versioned release or published image exists
-yet. Expect rough edges; do not run it against production fleets.
+end-to-end suite**. Version tags publish a multi-arch image and Helm
+chart to ghcr (see [docs/releasing.md](docs/releasing.md)). Expect rough
+edges; do not run it against production fleets.
 
 ## Features
 
@@ -97,12 +98,19 @@ additions, not rewrites.
 
 ## Getting started
 
-Install via the in-repo Helm chart (no published registry yet):
+Install a released version from the published Helm chart (pick a version
+from the [releases](https://github.com/moeritze/k8s-r8r/releases)):
 
 ```sh
-helm install k8s-r8r charts/k8s-r8r \
+helm install k8s-r8r oci://ghcr.io/moeritze/charts/k8s-r8r \
+  --version <x.y.z> \
   --namespace k8s-r8r-system --create-namespace
 ```
+
+The chart pulls the matching operator image
+(`ghcr.io/moeritze/k8s-r8r`) automatically. For development, install the
+in-repo chart instead (`helm install k8s-r8r charts/k8s-r8r ...` with a
+locally built image — see the quickstart).
 
 Requires Kubernetes **1.30+** and, for the optional advisory webhook,
 cert-manager (or bring your own cert — see the chart's `values.yaml`).
@@ -115,6 +123,7 @@ fleet walkthrough.
 | Doc | Contents |
 |---|---|
 | [docs/quickstart.md](docs/quickstart.md) | kind fleet, Helm install, annotate-a-Secret walkthrough |
+| [docs/releasing.md](docs/releasing.md) | release process: tag → published image + chart + GitHub release |
 | [docs/annotations.md](docs/annotations.md) | full `r8r.io/*` annotation reference |
 | [docs/policies.md](docs/policies.md) | `ReplicationPolicy` authoring guide |
 | [docs/gitops.md](docs/gitops.md) | ArgoCD integration, ignore rules, sealed-secrets/ESO complementarity |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,6 +14,26 @@ Secret for replication.
 - Optional: [cert-manager](https://cert-manager.io) on the hub for the
   advisory webhook (the quickstart skips it)
 
+## Install from published artifacts
+
+Released versions ship as a container image
+(`ghcr.io/moeritze/k8s-r8r:<tag>`) and a Helm chart in an OCI registry —
+no clone or local build needed. Pick a version from the
+[releases page](https://github.com/moeritze/k8s-r8r/releases) and:
+
+```sh
+helm install k8s-r8r oci://ghcr.io/moeritze/charts/k8s-r8r \
+  --version <x.y.z> \
+  --namespace k8s-r8r-system --create-namespace
+```
+
+The chart's default image repository and tag point at the image published
+for that release, so the operator image is pulled automatically. See
+[releasing.md](releasing.md) for how releases are cut.
+
+The rest of this quickstart is the **development path**: build the image
+locally and run it on a kind fleet.
+
 ## 1. Create a local fleet
 
 ```sh

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,50 @@
+# Releasing
+
+How a k8s-r8r release happens, and what it publishes.
+
+## Cutting a release
+
+Releases are cut by pushing a semver tag:
+
+```sh
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+The tag push triggers `.github/workflows/release.yml`, which publishes
+three artifacts:
+
+| Artifact | Location |
+|---|---|
+| Operator image (multi-arch: linux/amd64, linux/arm64) | `ghcr.io/moeritze/k8s-r8r:<tag>` — plus `:latest` for stable tags |
+| Helm chart | `oci://ghcr.io/moeritze/charts/k8s-r8r`, chart version `<tag without v>` |
+| GitHub release | Generated notes on the [releases page](https://github.com/moeritze/k8s-r8r/releases) |
+
+The chart is packaged with `--app-version <tag>`, so its default image tag
+(`.Chart.AppVersion`) resolves to the image published by the same run —
+`helm install` from the OCI chart pulls the matching image with no value
+overrides.
+
+## Prereleases
+
+Tags containing `-` follow the prerelease convention `-alpha.N` (e.g.
+`v0.2.0-alpha.1`). They:
+
+- are marked **prerelease** on the GitHub release,
+- do **not** move the `:latest` image tag.
+
+Stable tags (`v0.2.0`) also push `:latest` and publish a normal release.
+
+## One-time setup note (ghcr visibility)
+
+GitHub Container Registry packages may default to **private** on first
+publish. After the first release creates the `k8s-r8r` image package and
+the `charts/k8s-r8r` chart package, a maintainer must flip each package's
+visibility to **public** in the package settings on GitHub (one-time per
+package). Until then, anonymous pulls fail.
+
+## Authentication
+
+The workflow authenticates to ghcr with the workflow's `GITHUB_TOKEN`
+(`packages: write`); no extra secrets are configured. All actions are
+pinned to commit SHAs, matching the CI workflow's hardening style.

--- a/obsidian/development.md
+++ b/obsidian/development.md
@@ -14,6 +14,10 @@ kubebuilder project, module `github.com/moeritze/k8s-r8r`, API group `r8r.io/v1a
 2. **e2e** — `make test-e2e`: provisions a real kind fleet (`hack/kind-fleet.sh`, hub + 2 spokes), simulates ClusterAPI with a minimal CRD + status-patched `Cluster` objects + `--internal` kubeconfig Secrets, exercises full [[replication-flow]], [[cluster-discovery|cluster lifecycle]], and scale. `K8S_R8R_E2E_KEEP=1` keeps the fleet for debugging.
 3. **CI** (`.github/workflows/ci.yml`) — lint (custom golangci-lint w/ logcheck), test, build, e2e. Lint runs the same binary locally via `make lint`.
 
+## Release process
+
+Pushing a semver tag (`v*`) triggers `.github/workflows/release.yml`: multi-arch image (amd64/arm64) → `ghcr.io/moeritze/k8s-r8r:<tag>` (stable tags also move `:latest`), Helm chart → `oci://ghcr.io/moeritze/charts/k8s-r8r` (chart version = tag without `v`, appVersion = tag, so the chart's default image tag matches the published image), plus a GitHub release with generated notes. Tags containing `-` (`-alpha.N` convention) are prereleases and never move `:latest`. Actions SHA-pinned, `GITHUB_TOKEN` only. Install side: [[operations]]; full walkthrough: `../docs/releasing.md`.
+
 ## Documentation workflow (keep in sync — part of every change)
 
 Three layers, updated together:

--- a/obsidian/operations.md
+++ b/obsidian/operations.md
@@ -22,6 +22,6 @@ Leader election (single writer, standby failover from persisted CRs/inventory). 
 
 ## Install / uninstall
 
-Helm chart `charts/k8s-r8r` (webhook cert-manager toggle, personas, metrics). Teardown order matters: remove annotations/policies → replicas GC → `helm uninstall`; finalizer escape hatch documented in `../docs/uninstall.md`.
+Released versions install from the published chart: `helm install k8s-r8r oci://ghcr.io/moeritze/charts/k8s-r8r --version <x.y.z>` — pulls the matching `ghcr.io/moeritze/k8s-r8r` image automatically ([[development|release process]], `../docs/releasing.md`). For development, the in-repo chart `charts/k8s-r8r` (webhook cert-manager toggle, personas, metrics). Teardown order matters: remove annotations/policies → replicas GC → `helm uninstall`; finalizer escape hatch documented in `../docs/uninstall.md`.
 
 Spec: `openspec/specs/observability-operations`

--- a/openspec/changes/add-release-publishing/.openspec.yaml
+++ b/openspec/changes/add-release-publishing/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-24
+skip_specs: true

--- a/openspec/changes/add-release-publishing/design.md
+++ b/openspec/changes/add-release-publishing/design.md
@@ -1,0 +1,42 @@
+# Design — release publishing
+
+## Context
+
+See proposal.md — Why. Repo CI style: SHA-pinned actions, `permissions: {}`
+at workflow top level with per-job grants. Chart already defaults
+`image.repository` to `ghcr.io/moeritze/k8s-r8r` and falls back to
+`.Chart.AppVersion` for the tag.
+
+## Decisions
+
+- **Trigger**: push of tags `v*`. The tag is the single source of truth:
+  image tag = `<tag>`, chart version = `<tag without v>`, chart appVersion =
+  `<tag>` — so the chart's default image tag (`.Chart.AppVersion`) resolves
+  to the image published by the same run.
+- **`:latest` gating**: only tags without `-` (non-prerelease semver) also
+  push `:latest`. Prereleases (`v0.2.0-alpha.1`) never move `latest`.
+- **Registry**: ghcr.io with `GITHUB_TOKEN` (`packages: write`) — no extra
+  secrets. Chart goes to `oci://ghcr.io/moeritze/charts` so image and chart
+  packages don't collide.
+- **Action pinning**: docker/* actions pinned to commit SHAs resolved from
+  the GitHub API at authoring time (latest releases); `actions/checkout`
+  reuses the SHA already pinned in ci.yml.
+- **GitHub release via `gh` CLI** (`gh release create --generate-notes`)
+  instead of a third-party release action — one fewer supply-chain pin;
+  `gh` is preinstalled on runners. Same for `helm` (preinstalled).
+
+## Risks / Trade-offs
+
+- [ghcr packages default to private on first publish] → one-time manual
+  visibility flip by the maintainer, documented in docs/releasing.md.
+- [multi-arch arm64 build under QEMU is slow] → acceptable for tag-only
+  cadence; no PR latency impact.
+
+## Migration Plan
+
+Additive only. Rollback = delete the workflow file; published artifacts are
+immutable and stay available.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-release-publishing/proposal.md
+++ b/openspec/changes/add-release-publishing/proposal.md
@@ -1,0 +1,45 @@
+# Add release publishing
+
+## Why
+
+k8s-r8r has no published artifacts: no container image on a registry and no
+chart in an OCI repository. Anyone who wants to run the operator on a real
+cluster must clone the repo and build the image themselves, which blocks
+real-cluster adoption and makes the "install via Helm" story in the README
+half-true.
+
+## What Changes
+
+- New tag-triggered GitHub Actions workflow (`.github/workflows/release.yml`)
+  that, on push of a `v*` tag:
+  - builds and pushes a multi-arch (linux/amd64, linux/arm64) operator image
+    to `ghcr.io/moeritze/k8s-r8r:<tag>` (plus `:latest` for non-prerelease
+    semver tags),
+  - packages the Helm chart with `--version <tag without v>` /
+    `--app-version <tag>` and pushes it to `oci://ghcr.io/moeritze/charts`,
+  - creates a GitHub release with generated notes (marked prerelease when
+    the tag contains `-`).
+- Docs: "Install from published artifacts" section in `docs/quickstart.md`,
+  new `docs/releasing.md`, updated README install snippet, updated
+  `obsidian/development.md` and `obsidian/operations.md`.
+
+No operator behavior changes. This is pure release tooling + docs, hence
+`skip_specs: true`.
+
+## Capabilities
+
+### New Capabilities
+
+None — release tooling only, no spec-level behavior.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `.github/workflows/release.yml` (new)
+- `docs/quickstart.md`, `docs/releasing.md` (new), `README.md`
+- `obsidian/development.md`, `obsidian/operations.md`
+- No Go code, no chart template changes (values.yaml already defaults to
+  `ghcr.io/moeritze/k8s-r8r` with the `.Chart.AppVersion` tag fallback).

--- a/openspec/changes/add-release-publishing/tasks.md
+++ b/openspec/changes/add-release-publishing/tasks.md
@@ -1,0 +1,24 @@
+## 1. Release workflow
+
+- [x] 1.1 Add `.github/workflows/release.yml` triggered on `v*` tag push, top-level `permissions: {}`, per-job grants (`packages: write` for publish jobs, `contents: write` for the release job)
+- [x] 1.2 Job `publish-image`: buildx multi-arch (linux/amd64, linux/arm64) from the existing Dockerfile, login to ghcr with `GITHUB_TOKEN`, push `ghcr.io/moeritze/k8s-r8r:<tag>` and `:latest` only for non-prerelease tags; SHA-pin all actions
+- [x] 1.3 Job `publish-chart`: `helm package charts/k8s-r8r --version <tag without v> --app-version <tag>`, `helm registry login ghcr.io`, `helm push` to `oci://ghcr.io/moeritze/charts`
+- [x] 1.4 Job `github-release`: after both publish jobs, `gh release create <tag> --generate-notes`, `--prerelease` when the tag contains `-`
+- [x] 1.5 Verify workflow YAML parses
+
+## 2. Chart alignment
+
+- [x] 2.1 Confirm values.yaml default image repository is `ghcr.io/moeritze/k8s-r8r` and deployment falls back to `.Chart.AppVersion` for the tag
+- [x] 2.2 `helm lint charts/k8s-r8r` and `helm template` with default values stay green
+
+## 3. Docs
+
+- [x] 3.1 `docs/quickstart.md`: add "Install from published artifacts" section (OCI chart install), keep kind/dev flow as the dev path
+- [x] 3.2 Add `docs/releasing.md` (tag → workflow → artifacts; prerelease convention; one-time ghcr visibility note)
+- [x] 3.3 Update README install snippet to the published chart
+- [x] 3.4 Update `obsidian/development.md` (release process) and `obsidian/operations.md` (install pointer)
+
+## 4. Verification
+
+- [x] 4.1 `openspec validate add-release-publishing --strict` passes
+- [x] 4.2 `go build ./...` still green (no Go changes expected)


### PR DESCRIPTION
## Summary

Adds a tag-triggered release pipeline so the operator becomes installable from published artifacts. Pushing a semver tag `v*` now publishes:

| Artifact | Destination |
|---|---|
| Multi-arch operator image (linux/amd64, linux/arm64) | `ghcr.io/moeritze/k8s-r8r:<tag>` — stable tags (no `-`) also move `:latest` |
| Helm chart | `oci://ghcr.io/moeritze/charts/k8s-r8r`, chart version `<tag without v>`, appVersion `<tag>` |
| GitHub release | Generated notes; marked prerelease when the tag contains `-` (`-alpha.N` convention) |

The chart is packaged with `--app-version <tag>`, so its default image tag (`.Chart.AppVersion` fallback in the deployment template) resolves to the image published by the same run — `helm install oci://...` pulls the matching image with zero value overrides.

## Workflow hardening

- Top-level `permissions: {}`, per-job grants (`packages: write` for the two publish jobs, `contents: write` for the release job) — matching ci.yml style
- All actions pinned to commit SHAs resolved from the GitHub API (docker/setup-qemu v4.2.0, setup-buildx v4.3.0, login v4.6.0, build-push v7.3.0; checkout reuses the ci.yml pin)
- GitHub release and chart push use the runner-preinstalled `gh` / `helm` CLIs instead of third-party actions — fewer supply-chain pins
- `GITHUB_TOKEN` only, no extra secrets

## Docs (same PR)

- `docs/quickstart.md`: new "Install from published artifacts" section; kind flow kept as the dev path
- `docs/releasing.md` (new): release process, prerelease convention, auth
- README: install snippet now uses the OCI chart; status paragraph and docs table updated
- `obsidian/development.md` (release process paragraph) + `obsidian/operations.md` (install pointer), wikilinked

## OpenSpec

`openspec/changes/add-release-publishing/` — proposal, brief design, tasks (all checked). Pure release tooling, no spec-level behavior change → `skip_specs: true`; `openspec validate --strict` passes.

## One-time note for the maintainer

ghcr packages may default to **private** on first publish. After the first tagged release, flip visibility of the `k8s-r8r` image package and the `charts/k8s-r8r` chart package to public in the GitHub package settings (one-time per package); anonymous pulls fail until then.

## Verification

- `helm lint charts/k8s-r8r` ✓, `helm template` with defaults renders ✓ (`ghcr.io/moeritze/k8s-r8r:0.1.0`)
- Both workflow files YAML-parse ✓
- `go build ./...` ✓ (no Go changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
