### PR TITLE
chore: ignore agent worktree scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ go.work
 
 # local agent/tooling scratch state
 .remember/
+.claude/worktrees/
 
 # Kubeconfig might contain secrets
 *.kubeconfig


### PR DESCRIPTION
Parallel agent runs create git worktrees under `.claude/worktrees/`, which sits inside an otherwise-tracked directory. Those trees contain build output and downloaded envtest binaries.

Ignoring them so nothing from an agent scratch tree can be committed to this public repo by accident.

One line in `.gitignore`; no behavior change.