### PR TITLE
docs: make spoke RBAC claims match the implementation

### DIFF
--- a/charts/k8s-r8r/templates/NOTES.txt
+++ b/charts/k8s-r8r/templates/NOTES.txt
@@ -1,8 +1,21 @@
 k8s-r8r {{ .Chart.AppVersion }} installed in namespace {{ .Release.Namespace }}.
 
-Nothing replicates yet: the policy universe is default-deny. Create a
-ReplicationPolicy (see docs/policies.md), then annotate a Secret or
-ConfigMap:
+Nothing replicates yet: the policy universe is default-deny.
+
+But installing is not a no-op on your fleet. As soon as a discovered
+cluster reports control-plane-ready, the operator uses its provider admin
+kubeconfig once to bootstrap credentials there — a k8s-r8r-system
+namespace, a k8s-r8r ServiceAccount, and a ClusterRole granting
+get/list/watch/create/update/patch/delete on {{ join ", " .Values.allowedKinds }}
+in every namespace of that cluster. This happens before any policy
+exists, and the grant follows --allowed-kinds, not your policies. Set
+allowedKinds to the kinds you actually replicate, and read
+docs/security.md before pointing this at production.
+
+  kubectl get clusterrole k8s-r8r-replicator -o yaml   # on a spoke
+
+To start replicating, create a ReplicationPolicy (see docs/policies.md),
+then annotate a Secret or ConfigMap:
 
   kubectl annotate secret my-secret \
     r8r.io/replicate="true" \

--- a/docs/security.md
+++ b/docs/security.md
@@ -59,23 +59,64 @@ equal fleet-admin compromise. Instead:
    kubeconfig (`<cluster>-kubeconfig` Secret) with an **uncached read**
    and uses it **exactly once per bootstrap** to create on the spoke:
    the `k8s-r8r-system` namespace, the `k8s-r8r` ServiceAccount, the
-   `k8s-r8r-replicator` ClusterRole (verbs on exactly the allowlisted
-   resource kinds, plus `get`/`create`/`patch` on namespaces
-   (namespace-ensure uses server-side apply) — never delete),
-   its binding, and a namespaced Role that lets the SA mint its own
-   tokens.
+   `k8s-r8r-replicator` ClusterRole, its binding, and a namespaced Role
+   that lets the SA mint its own tokens.
 2. All steady-state traffic authenticates with **short-lived, rotated SA
    tokens**; the spoke rest config carries no static credential at all
    (every request is re-signed with a currently valid token). Token
    renewal authenticates as the SA itself, not the admin credential.
 3. Spoke RBAC is **re-narrowed** when the configured kind allowlist
-   shrinks.
+   shrinks: the ClusterRole rules are replaced wholesale at bootstrap,
+   and changing `--allowed-kinds` restarts the operator, which
+   re-bootstraps every discovered cluster at the smaller scope.
 
-Result: hub compromise blast radius drops from "fleet admin" to "write
-allowlisted kinds in spoke namespaces" — still serious, but bounded and
-auditable. Known v1 limitation (documented in the code): the spoke grant
-is a ClusterRole, so it applies in all namespaces of the spoke;
-per-namespace narrowing is a planned refinement.
+### What the spoke grant actually is
+
+Be precise about this, because it sizes everything else. The
+`k8s-r8r-replicator` ClusterRole grants, on **each kind in
+`--allowed-kinds`** (default `secrets,configmaps`):
+
+```
+get, list, watch, create, update, patch, delete
+```
+
+plus `get`/`create`/`patch` on namespaces (namespace-ensure uses
+server-side apply, whose create-on-PATCH path needs both — never
+delete). There are no `resourceNames`, and it is bound with a
+**ClusterRoleBinding**, so those verbs apply in **every namespace** of
+the spoke. The `app.kubernetes.io/managed-by` label selector on the
+operator's spoke caches narrows what k8s-r8r *watches*; it is a cache
+filter, not an authorization boundary.
+
+Two narrowings the design intends are **not implemented yet**:
+
+- **Scope is not derived from policy.** It comes from the operator's
+  `--allowed-kinds` flag, never from your `ReplicationPolicy` objects.
+  A hub whose only policy permits `Secret` still grants ConfigMap
+  `delete` on every spoke, and the grant is created when the operator
+  first discovers a cluster — before any policy exists.
+  ([#29](https://github.com/moeritze/k8s-r8r/issues/29))
+- **Scope is not per-namespace.** Per-namespace Roles instead of a
+  ClusterRole are a planned refinement.
+
+Result: hub compromise blast radius drops from "fleet admin" to
+"read/write/delete the allowlisted kinds in every namespace of every
+spoke, plus create namespaces". That is a real reduction — no node,
+workload, or RBAC control — but with `secrets` allowlisted it still
+means reading and deleting every Secret in `kube-system`,
+`cert-manager`, `argocd` and the like, so treat it as *narrower than*
+fleet admin rather than as bounded. Sizing note: this is not a privilege
+**escalation** — the hub already holds the CAPI admin kubeconfigs, so
+the SA grant reaches nothing a hub compromise could not already reach.
+What the gap defeats is the *reduction* D5 promises: the SA is meant to
+be a much smaller thing to fall back to, and today it is less small than
+the design intends. The reductions D5 does deliver in full — no static
+credential in the spoke rest config, short-lived rotated tokens, the
+admin kubeconfig touched once per bootstrap — are unaffected.
+
+Until policy-derived scoping lands, the operator lever that actually
+narrows spokes is `--allowed-kinds` (chart value `allowedKinds`): set it
+to the kinds you really replicate.
 
 Hub-side hardening that complements this: keep CAPI kubeconfig Secrets in
 an isolated namespace with tight RBAC — they are the crown jewels of a
@@ -188,3 +229,11 @@ does not.
   grade privilege; bind `k8s-r8r-policy-admin` accordingly.
 - Readers of replicas on target clusters — replicas are ordinary
   Secrets/ConfigMaps there; spoke-side RBAC governs who reads them.
+- Objects on a spoke that k8s-r8r never touches. The spoke SA's grant is
+  scoped to the *configured* kind allowlist across all namespaces, not to
+  what policy permits or to what has actually been replicated, so it can
+  read and delete allowlisted kinds anywhere on the spoke — including
+  namespaces no `ReplicationPolicy` names. Narrow `allowedKinds` to what
+  you replicate; policy-derived scoping is tracked in
+  [#29](https://github.com/moeritze/k8s-r8r/issues/29). See
+  [What the spoke grant actually is](#what-the-spoke-grant-actually-is).

--- a/internal/cluster/bootstrap.go
+++ b/internal/cluster/bootstrap.go
@@ -60,15 +60,32 @@ type ScopedResource struct {
 	Resource string
 }
 
-// RBACScope parameterizes the spoke ClusterRole by the resource kinds the
-// current policy universe requires. Callers re-narrow by calling
-// Bootstrapper.UpdateRBAC with a smaller scope when the policy universe
-// shrinks.
+// RBACScope parameterizes the spoke ClusterRole by the resource kinds
+// replication is allowed to touch. Callers re-narrow by calling
+// Bootstrapper.UpdateRBAC with a smaller scope; Rules() is a full
+// replacement, so a smaller scope drops the removed kinds outright.
 //
-// v1 limitation: scoping is via a ClusterRole, so granted verbs apply in all
-// namespaces of the spoke (wildcard namespace scope). Narrowing to specific
-// namespaces (per-namespace Roles) is a future refinement; the RBACScope
-// type is the stable seam for it.
+// Two v1 limitations, both of which RBACScope is the stable seam for:
+//
+//   - Kind scope is not policy-derived. In production the only caller builds
+//     this from the --allowed-kinds flag (see parseAllowedKinds in
+//     cmd/main.go), not from the installed ReplicationPolicy objects, so the
+//     grant is a superset of what policy permits and exists from the moment a
+//     cluster is discovered, before any policy is authored. Re-narrowing
+//     therefore only tracks an --allowed-kinds change (which restarts the
+//     operator and re-bootstraps every spoke), never a policy change.
+//     Deriving the scope from the policy universe is deferred because
+//     *widening* a grant requires a credential that can escalate: doing it on
+//     every policy edit would turn the provider admin kubeconfig from a
+//     one-shot bootstrap credential into a routinely used one, which costs
+//     more than the over-broad grant it buys back (design D5). Tracked in
+//     issue #29.
+//   - Namespace scope is a wildcard. Scoping is via a ClusterRole, so granted
+//     verbs apply in all namespaces of the spoke. Narrowing to specific
+//     namespaces (per-namespace Roles) is a future refinement.
+//
+// Both limitations are disclosed in docs/security.md; keep that section and
+// this comment in sync with whatever an implementation changes here.
 type RBACScope struct {
 	// Resources are the replicated resource kinds.
 	Resources []ScopedResource

--- a/obsidian/security-model.md
+++ b/obsidian/security-model.md
@@ -19,6 +19,15 @@ Full write-up: `../docs/security.md`. Core stances:
 
 Hub holds fleet write access → mitigated by [[cluster-discovery#credential-bootstrap-d5|one-shot narrow SA bootstrap]]: admin kubeconfig used once, steady state runs on short-lived rotated SA tokens scoped to allowlisted kinds. Pull-agent transport is a future `Transport` implementation.
 
+**How narrow the SA actually is (be precise, the docs used to overstate this).** The spoke `k8s-r8r-replicator` ClusterRole grants `get,list,watch,create,update,patch,delete` on each kind in `--allowed-kinds` (default `secrets,configmaps`) plus `get,create,patch` on namespaces — no `resourceNames`, and bound via ClusterRoleBinding, so **every namespace** of the spoke. The `managed-by` selector on spoke caches filters what the operator *watches*; it is not an authz boundary.
+
+Two intended narrowings are not built yet:
+
+- **Not policy-derived** — scope comes from the `--allowed-kinds` flag, never from [[policy-model]]. Grant is a superset of what policy permits and exists from first cluster discovery, before any policy. Re-narrowing tracks an `--allowed-kinds` change (restart → re-bootstrap every spoke, full rule replacement), not a policy change. Deferred because *widening* needs an escalation-capable credential, so policy-driven widening would demote the admin kubeconfig from one-shot to routine — worse for D5 than the broad grant. Tracked: [#29](https://github.com/moeritze/k8s-r8r/issues/29).
+- **Not per-namespace** — ClusterRole, not per-namespace Roles. `RBACScope` (`internal/cluster/bootstrap.go`) is the seam for both.
+
+So: reduction from fleet admin is real (no node/workload/RBAC control) but **narrower-than, not bounded** — with `secrets` allowlisted the SA reads and deletes every Secret in `kube-system`, `cert-manager`, `argocd`. Sizing: not an *escalation* (hub already holds the CAPI admin kubeconfigs), it defeats the *reduction* D5 promises. Untouched and fully delivered: no static credential in the spoke rest config, short-lived rotated tokens, admin kubeconfig used once per bootstrap. Operator lever until #29 lands: chart `allowedKinds`.
+
 ## Advisory webhook doctrine (D6)
 
 Validating webhook (CEL matchConditions: fires only on objects carrying `r8r.io/` annotations; K8s ≥ 1.30) gives apply-time errors naming the failing policy dimension. `failurePolicy: Ignore` is **mandatory** — `Fail` would let operator downtime block all annotated secret writes. Security never depends on it: reconcile-time policy evaluation is authoritative; a bypassed webhook means worse error messages, never unauthorized replication.
@@ -30,7 +39,7 @@ No log, event, condition, or metric ever contains payload data — hashes only. 
 ## Weaponization guards
 
 - `Overwrite` conflict mode could replace a victim cluster's secret → policy-gated, `Fail` default; replicas of a *different* source are never taken over ([[replication-flow]]).
-- Exfiltration via annotation → blocked by default-deny [[policy-model]]; no request-side override exists.
+- Exfiltration via annotation → blocked by default-deny [[policy-model]]; no request-side override exists. ⚠️ This claim is disputed — see [#26](https://github.com/moeritze/k8s-r8r/issues/26) / [#34](https://github.com/moeritze/k8s-r8r/issues/34); corrected wording lands with that fix, not here.
 
 ## Supply chain
 

--- a/openspec/changes/document-spoke-rbac-kind-scope/.openspec.yaml
+++ b/openspec/changes/document-spoke-rbac-kind-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/document-spoke-rbac-kind-scope/README.md
+++ b/openspec/changes/document-spoke-rbac-kind-scope/README.md
@@ -1,0 +1,3 @@
+# document-spoke-rbac-kind-scope
+
+Amend the cluster-discovery minimal-privilege bootstrap requirement to describe the implemented kind-allowlist scoping and record policy-derived scoping as deferred (tracking issue #29).

--- a/openspec/changes/document-spoke-rbac-kind-scope/design.md
+++ b/openspec/changes/document-spoke-rbac-kind-scope/design.md
@@ -1,0 +1,94 @@
+# Design
+
+## Context
+
+Issue #29 reports that spoke RBAC is neither derived from the policy universe
+nor re-narrowed. Verification against the tree splits that into two findings
+with different dispositions.
+
+**Verified as drift (spec is wrong, code is the reality):** the bootstrap
+`RBACScope` comes from `--allowed-kinds` only. The grant is
+`get,list,watch,create,update,patch,delete` on each allowlisted resource
+(`internal/cluster/bootstrap.go:52`) with no `resourceNames` and no namespace
+restriction, bound cluster-wide via a ClusterRoleBinding
+(`internal/cluster/bootstrap.go:193-212`), plus `get,create,patch` on
+namespaces. The `managed-by` label selector set on each spoke runtime
+(`cmd/main.go:446-451`) is a *cache* filter, not an authorization boundary.
+
+**Verified as already-working but undocumented:** re-narrowing on an allowlist
+shrink. `UpdateRBAC` assigns `existing.Rules = desired`
+(`internal/cluster/bootstrap.go:168`) — a full replacement, not a merge — and a
+restart replays bootstrap for every spoke.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- The spec describes what the code does, and names what it does not do.
+- The deferral is recorded with its reason and a tracking issue, so a reader
+  can tell "not yet built" from "overlooked".
+- The implemented shrink path gets the scenario it never had.
+- Security docs stop overstating the blast-radius reduction.
+
+**Non-Goals**
+
+- Implementing policy-derived scoping. That needs the admin-credential decision
+  below and gets its own change.
+- Per-namespace narrowing (already a known, separately documented limitation).
+- Any behavior change whatsoever in this change.
+
+## Decisions
+
+### Restate the requirement rather than weaken it
+
+The alternative was to leave the aspirational wording and add a caveat. Rejected:
+a SHALL that nothing implements and nothing tests is indistinguishable from a
+lie in an audit, and the spec is meant to be the source of truth for what the
+operator does today. The aspiration is preserved as an explicit deferral with
+an issue reference, which is honest about both the current state and the
+intent.
+
+### Keep the blast-radius correction factual, not alarmist
+
+The current text — reduction "from fleet admin to write allowlisted kinds in
+spoke namespaces — still serious, but bounded and auditable" — overstates the
+reduction: read-and-delete on every Secret in every namespace of every spoke
+(`kube-system`, `cert-manager`, `argocd`, `flux-system` included) is not
+meaningfully bounded away from fleet admin.
+
+The correction says so, and also says what stays true: this is not a privilege
+*escalation*. The hub already holds CAPI admin kubeconfigs, so the spoke SA
+grant adds no reach a hub compromise did not already have. What the gap defeats
+is the *reduction* design D5 promises — the SA is supposed to be the thing you
+fall back to, and today it is not much smaller than what it replaces. The
+genuine reductions D5 does deliver (no static credential in the spoke rest
+config, short-lived rotated tokens, admin kubeconfig touched once per
+bootstrap) are unaffected and stay stated.
+
+### Why policy-derived scoping is deferred rather than fixed here
+
+The naive shape — watch `ReplicationPolicy`, recompute the scope, call
+`UpdateRBAC` — is worse than the bug it fixes. Widening a spoke grant needs a
+credential that can escalate, which means holding the provider admin
+kubeconfig for routine policy edits instead of once per bootstrap, converting
+an auditable rare event into a routine one and undermining D5 more than the
+over-broad grant does.
+
+The promising alternative is to let the spoke SA narrow *itself*: grant it
+`get,update` on its own ClusterRole by `resourceNames`, so RBAC
+escalation-prevention makes widening structurally impossible while narrowing
+needs no admin credential, and widening stays a bootstrap-class event. That is
+a real design decision with a real blast-radius argument on both sides, and it
+belongs in its own change with its own review — not smuggled in behind a docs
+pass.
+
+## Risks / Trade-offs
+
+- **Disclosing a posture limitation in a public repo.** Mitigated by framing:
+  this is a documented alpha limitation with a tracking issue, not a
+  vulnerability with an exploit path, and it grants no reach a hub compromise
+  did not already have. Leaving the docs overstating the reduction is the worse
+  option — an operator could size their trust in the spoke SA boundary against
+  a promise the code does not keep.
+- **The spec temporarily encodes a weaker guarantee.** Accepted deliberately;
+  #29 tracks restoring the stronger one, and the deferral text names it.

--- a/openspec/changes/document-spoke-rbac-kind-scope/proposal.md
+++ b/openspec/changes/document-spoke-rbac-kind-scope/proposal.md
@@ -1,0 +1,78 @@
+# Document spoke RBAC kind scope
+
+## Why
+
+`openspec/specs/cluster-discovery/spec.md:28` (requirement *Minimal-privilege
+credential bootstrap*) promises spoke RBAC "limited to the verbs, kinds, and
+namespace-creation rights **the policy universe** requires" and re-narrowing
+"when **the policy universe** shrinks". Neither half is implemented, and the
+spec has read that way since the operator was bootstrapped.
+
+What is implemented is scoping to the operator's *configured kind allowlist*:
+`parseAllowedKinds` (`cmd/main.go:82-112`) turns the `--allowed-kinds` flag
+(`cmd/main.go:312`, default `secrets,configmaps`) into the `cluster.RBACScope`
+handed to the spoke wirer (`cmd/main.go:456`). Nothing in the tree reads a
+`ReplicationPolicy` to build that scope. So a hub whose only policy permits
+`Secret` still grants cluster-wide ConfigMap `delete` on every discovered
+spoke, and the grant is created at install time, before any policy exists.
+
+The re-narrowing half is *partially* implemented and undocumented as such:
+`UpdateRBAC` replaces the ClusterRole rules wholesale
+(`internal/cluster/bootstrap.go:168`), and because `--allowed-kinds` can only
+change through a Deployment edit — which restarts the pod, after which the
+discovery provider re-emits a Register event for every cluster present at
+startup (`internal/discovery/discovery.go:101`) — every spoke re-bootstraps at
+the new, narrower scope. `TestUpdateRBACReNarrows` covers the replacement.
+This behavior has no scenario.
+
+Closing the real gap (policy-derived scoping) is a 10-14h implementation that
+first needs a deliberate decision about whether the provider admin credential
+stays one-shot; widening a spoke grant on every policy edit would turn an
+auditable bootstrap-class event into a routine one. That decision gets its own
+change. This change makes the written contract match the code in the meantime,
+so the drift is disclosed rather than implied to be fixed.
+
+## What Changes
+
+- **Spec (`cluster-discovery`)**: amend *Minimal-privilege credential
+  bootstrap* to state that the spoke grant is scoped to the configured kind
+  allowlist and re-narrowed when that allowlist shrinks; record policy-derived
+  scoping and per-namespace narrowing as explicitly deferred, with issue #29 as
+  the tracking issue. Add a scenario for the kind-allowlist shrink, which is
+  implemented and previously had no scenario.
+- **`docs/security.md`**: state the actual verb list and the all-namespaces
+  ClusterRole scope at the point where the D5 promise is made; replace the
+  "bounded and auditable" blast-radius claim with an accurate one; add the
+  policy-derivation gap to "What k8s-r8r does not protect against".
+- **`internal/cluster/bootstrap.go`**: extend the `RBACScope` doc comment,
+  which today acknowledges only the namespace-wildcard limitation, to also
+  record the policy-derivation gap — that comment is where a future implementer
+  looks first. Comment only; no behavior change.
+- **`obsidian/security-model.md`**: match the corrected blast-radius wording.
+- **`charts/k8s-r8r/templates/NOTES.txt`**: say that installing bootstraps
+  credentials on every discovered ready cluster, before any policy exists.
+  Today the notes say "nothing replicates yet", which is true of replication
+  and easy to misread as "nothing has happened on my clusters".
+
+No operator behavior changes. Documentation and spec honesty only; the
+implementation remains outstanding under #29.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cluster-discovery` — *Minimal-privilege credential bootstrap* restated to
+  the implemented scoping, plus one new scenario.
+
+## Impact
+
+- `openspec/specs/cluster-discovery/spec.md` (via this change's delta)
+- `docs/security.md`
+- `internal/cluster/bootstrap.go` (doc comment only)
+- `obsidian/security-model.md`
+- `charts/k8s-r8r/templates/NOTES.txt`
+- Tracking issue for the outstanding implementation: #29

--- a/openspec/changes/document-spoke-rbac-kind-scope/specs/cluster-discovery/spec.md
+++ b/openspec/changes/document-spoke-rbac-kind-scope/specs/cluster-discovery/spec.md
@@ -1,0 +1,23 @@
+# cluster-discovery
+
+## MODIFIED Requirements
+
+### Requirement: Minimal-privilege credential bootstrap
+The system SHALL NOT operate against target clusters with fleet-management admin credentials. On registration, the operator SHALL use the provider's admin credential (for ClusterAPI: the `<cluster>-kubeconfig` Secret) exactly once per bootstrap to create a dedicated namespace, ServiceAccount, and RBAC scoped to the operator's configured kind allowlist (`--allowed-kinds`) plus the namespace-creation rights replica writes require, then obtain and use only that ServiceAccount's token for all replication traffic. Tokens SHALL be short-lived and rotated before expiry. RBAC on the spoke SHALL be re-narrowed when the configured kind allowlist shrinks.
+
+Two narrowings are deferred and MUST be documented wherever the bootstrap's privilege reduction is claimed:
+
+- **Policy-derived scoping.** The grant is derived from the configured kind allowlist, not from the policy universe (the kinds installed `ReplicationPolicy` objects actually permit). It is therefore a superset of what policy permits, and it exists from install time, before any policy is authored. Deriving it from the policy universe requires first deciding whether the provider's admin credential stays one-shot, since widening a grant needs a credential that can escalate. Tracked in issue #29.
+- **Namespace scoping.** The grant is a ClusterRole, so its verbs apply in every namespace of the spoke. Per-namespace Roles are a future refinement; `RBACScope` is the stable seam for both narrowings.
+
+#### Scenario: Steady-state traffic uses the narrow ServiceAccount
+- **WHEN** replicas are written to a bootstrapped target cluster
+- **THEN** the request is authenticated as the k8s-r8r ServiceAccount, not the ClusterAPI kubeconfig identity
+
+#### Scenario: Token expiry
+- **WHEN** a target's ServiceAccount token approaches expiry
+- **THEN** the operator obtains a fresh token without interrupting replication
+
+#### Scenario: Configured kind allowlist shrinks
+- **WHEN** the operator's `--allowed-kinds` configuration is reduced to a smaller set of kinds and the operator restarts with the new value
+- **THEN** each ready target cluster is re-bootstrapped at the smaller scope and its replication ClusterRole rules are replaced wholesale, so no rule for a removed kind remains on any target

--- a/openspec/changes/document-spoke-rbac-kind-scope/tasks.md
+++ b/openspec/changes/document-spoke-rbac-kind-scope/tasks.md
@@ -1,0 +1,35 @@
+## 1. Verify the claims against the code
+
+- [x] 1.1 Confirm the bootstrap `RBACScope` comes from `--allowed-kinds` and never from a `ReplicationPolicy` (`cmd/main.go:82-112`, `cmd/main.go:312`, `cmd/main.go:456`)
+- [x] 1.2 Confirm the granted verbs, the absence of `resourceNames`, and the cluster-wide binding (`internal/cluster/bootstrap.go:52`, `:89-104`, `:193-212`)
+- [x] 1.3 Confirm the `managed-by` selector is a cache filter, not an authorization boundary (`cmd/main.go:446-451`)
+- [x] 1.4 Confirm the allowlist-shrink re-narrow path exists: full rule replacement (`internal/cluster/bootstrap.go:168`), restart replays bootstrap for every cluster present at startup (`internal/discovery/discovery.go:101`), covered by `TestUpdateRBACReNarrows`
+- [x] 1.5 Confirm `DefaultRBACScope` is test-only and not on the production path
+
+## 2. Spec delta
+
+- [x] 2.1 Restate *Minimal-privilege credential bootstrap* to the implemented kind-allowlist scoping
+- [x] 2.2 Record policy-derived scoping as deferred, with the reason and issue #29 as tracker
+- [x] 2.3 Add the `Configured kind allowlist shrinks` scenario
+- [x] 2.4 `openspec validate document-spoke-rbac-kind-scope --strict` passes
+
+## 3. Docs
+
+- [x] 3.1 `docs/security.md` D5 section: state the real verb list and the all-namespaces ClusterRole scope where the promise is made
+- [x] 3.2 `docs/security.md`: replace the "bounded and auditable" blast-radius claim with an accurate one that keeps the non-escalation context
+- [x] 3.3 `docs/security.md`: add the policy-derivation gap to "What k8s-r8r does not protect against"
+- [x] 3.4 `internal/cluster/bootstrap.go`: extend the `RBACScope` doc comment with the policy-derivation limitation (comment only)
+- [x] 3.5 `obsidian/security-model.md`: match the corrected wording
+- [x] 3.6 `charts/k8s-r8r/templates/NOTES.txt`: state that installing bootstraps credentials on every discovered ready cluster
+
+## 4. Verification
+
+- [x] 4.1 `make lint` green
+- [x] 4.2 `make test` green
+- [x] 4.3 `helm lint charts/k8s-r8r` green
+
+## 5. Out of scope (tracked in #29)
+
+- [ ] 5.1 Derive the bootstrap scope from the policy universe
+- [ ] 5.2 Decide whether the provider admin credential stays one-shot, or the spoke SA narrows its own ClusterRole
+- [ ] 5.3 Re-narrow on policy-universe change without a restart


### PR DESCRIPTION
Documentation and spec honesty pass for #29. **No behavior change** — the RBAC implementation is still outstanding, so this uses `Refs`, not `Fixes`.

## What was wrong

`openspec/specs/cluster-discovery/spec.md:28` promises spoke RBAC "limited to the verbs, kinds, and namespace-creation rights **the policy universe** requires" and re-narrowed "when **the policy universe** shrinks". Neither half is implemented.

## Verified against the code

| Claim | Evidence |
|---|---|
| Scope comes from `--allowed-kinds`, never from a `ReplicationPolicy` | `parseAllowedKinds` builds the `cluster.RBACScope` (`cmd/main.go:82-112`), flag default `secrets,configmaps` (`cmd/main.go:312`), passed to the spoke wirer (`cmd/main.go:456`). No `ReplicationPolicy` read anywhere on that path. |
| Grant is `get,list,watch,create,update,patch,delete`, no `resourceNames`, no namespace scope | `replicaVerbs` (`internal/cluster/bootstrap.go:52`), `Rules()` (`:89-104`), bound via **ClusterRoleBinding** (`:193-212`). Plus namespaces `get,create,patch`. |
| `managed-by` selector is a cache filter, not authz | `o.Cache.DefaultLabelSelector` (`cmd/main.go:446-451`) |
| Re-narrowing on **allowlist** shrink *does* work | `UpdateRBAC` assigns `existing.Rules = desired` — full replacement, not merge (`internal/cluster/bootstrap.go:168`); an `--allowed-kinds` edit restarts the pod, and discovery re-emits Register "for every cluster present at startup" (`internal/discovery/discovery.go:101`). Covered by `TestUpdateRBACReNarrows`. |
| `DefaultRBACScope` is not on the production path | Only references are its own definition and `bootstrap_test.go` |

Net effect: a hub whose only policy permits `Secret` still grants cluster-wide ConfigMap `delete` on every spoke, and the spoke SA can read and delete every Secret in `kube-system`, `cert-manager`, `argocd`, `flux-system` — from install time, before any policy exists.

**`docs/security.md:71-73` and the README trust-model line were accurate** and are left intact (the shrink path is real). The drift is spec-vs-code, plus one overstated blast-radius sentence.

## Changes

- **OpenSpec change `document-spoke-rbac-kind-scope`** — restates *Minimal-privilege credential bootstrap* to the implemented kind-allowlist scoping, records policy-derived and per-namespace scoping as explicitly deferred with #29 as tracker, and adds the kind-allowlist-shrink scenario that this behavior never had. Delta lives in the change's own `specs/`; `openspec/specs/**` untouched.
- **`docs/security.md`** — new "What the spoke grant actually is" subsection with the real verb list and all-namespaces scope, right where the D5 promise is made. Replaces *"still serious, but bounded and auditable"*, which overstated the reduction. Adds the gap to "What k8s-r8r does not protect against".
- **`internal/cluster/bootstrap.go`** — the `RBACScope` doc comment acknowledged only the namespace wildcard; now records the policy-derivation gap beside it, with the reason it is deferred. **Comment only.**
- **`obsidian/security-model.md`** — matched to the corrected wording.
- **`charts/k8s-r8r/templates/NOTES.txt`** — "Nothing replicates yet" is true of replication and easy to misread as "nothing has happened on my clusters". Now states that installing bootstraps credentials on every discovered ready cluster, and renders the configured `allowedKinds` into the notes.

## Framing

Deliberately factual, not alarmist. This is **not a privilege escalation** — the hub already holds CAPI admin kubeconfigs, so the spoke SA reaches nothing a hub compromise could not already reach. What the gap defeats is the *reduction* design D5 promises. The reductions D5 does deliver in full (no static credential in the spoke rest config, short-lived rotated tokens, admin kubeconfig used once per bootstrap) are unaffected and stay stated.

## Why the implementation is deferred

The naive fix — watch `ReplicationPolicy`, recompute, call `UpdateRBAC` — is worse than the bug: *widening* a grant needs an escalation-capable credential, so policy-driven widening would demote the provider admin kubeconfig from a one-shot bootstrap credential to a routinely used one. That decision (including the "let the SA narrow itself via `resourceNames` on its own ClusterRole" alternative) deserves its own OpenSpec change and its own review. Captured in the change's `design.md`.

## Verification

- `make test` — all packages pass
- `golangci-lint run ./internal/cluster/...` — 0 issues
- `openspec validate document-spoke-rbac-kind-scope --strict` — valid
- `helm lint charts/k8s-r8r` + NOTES render checked

Note: bare `make lint` reports 6 pre-existing `staticcheck` SA5011 issues, all in `internal/engine/reconciler_test.go` and `internal/annotations/annotations_test.go`. They reproduce identically on a clean stash of this branch, and the reported paths resolve into a *sibling worktree* (`../agent-.../`) — `golangci-lint run` with no path argument is picking up neighbouring worktrees. Unrelated to this PR; flagged for whoever owns the lint config.

Refs #29