### PR TITLE
fix(events): record through the core v1 API so lastTimestamp is populated

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -483,10 +483,15 @@ func main() {
 	// Replication engine: pushes replicas through SA-token clients from the
 	// cluster runtime manager and hooks its lifecycle events for drift
 	// informers and re-enqueues.
+	// Deliberately the core/v1 recorder, not the (newer) events.k8s.io one:
+	// only this recorder populates firstTimestamp/lastTimestamp/count, which
+	// `kubectl get events --sort-by=.lastTimestamp` needs (issue #32).
+	//nolint:staticcheck // SA1019: deliberate; GetEventRecorder omits the legacy timestamps.
+	engineRecorder := mgr.GetEventRecorderFor("replication-engine")
 	engineReconciler := &engine.Reconciler{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorder("replication-engine"),
+		Recorder:      engineRecorder,
 		Transport:     engine.NewPushTransport(clusterManager, "k8s-r8r"),
 		Clusters:      engine.ProviderInventory{Provider: provider},
 		ClusterEvents: clusterManager,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -107,6 +107,13 @@ With **no ReplicationPolicy present, nothing replicates** — this is the
 default-deny security posture, not an error. The `Replication` status and
 events on the Secret report `PolicyDenied` with the failing dimension.
 
+Operator events are recorded through the core `v1` Event API, so the usual
+idiom works and orders them correctly:
+
+```sh
+kubectl -n demo get events --sort-by=.lastTimestamp
+```
+
 ## 4. Allow it with a ReplicationPolicy
 
 Policies are cluster-scoped, admin-owned allowlists (see

--- a/internal/controller/request/controller.go
+++ b/internal/controller/request/controller.go
@@ -81,7 +81,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -133,11 +133,6 @@ const (
 	EventReasonNameConflict = "ReplicationNameConflict"
 )
 
-// actionMaterialize is the events-API action recorded on request-controller
-// events: everything this controller does is part of materializing (or
-// refusing to materialize) a request.
-const actionMaterialize = "Materialize"
-
 // ConditionNotAuthoritative is the condition type set on hand-authored
 // Replication objects. Such objects are never reconciled (replication-request
 // spec: canonical Replication objects are operator-owned).
@@ -180,7 +175,13 @@ type Reconciler struct {
 
 	// Recorder emits events on sources and Replications; defaulted in
 	// SetupWithManager.
-	Recorder events.EventRecorder
+	//
+	// This is deliberately the core/v1 recorder (client-go tools/record, i.e.
+	// manager.GetEventRecorderFor) and not the events.k8s.io one: only the
+	// core recorder populates firstTimestamp/lastTimestamp/count, which the
+	// universal `kubectl get events --sort-by=.lastTimestamp` idiom needs
+	// (issue #32).
+	Recorder record.EventRecorder
 
 	// Inventory supplies cluster snapshots for target resolution. Required.
 	Inventory ClusterInventory
@@ -221,7 +222,11 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		r.Scheme = mgr.GetScheme()
 	}
 	if r.Recorder == nil {
-		r.Recorder = mgr.GetEventRecorder("request-controller")
+		// Deliberately the core/v1 recorder, not the (newer) events.k8s.io one:
+		// only this recorder populates firstTimestamp/lastTimestamp/count, which
+		// `kubectl get events --sort-by=.lastTimestamp` needs (issue #32).
+		//nolint:staticcheck // SA1019: see above; GetEventRecorder omits the legacy timestamps.
+		r.Recorder = mgr.GetEventRecorderFor("request-controller")
 	}
 
 	allow := r.Allowlist
@@ -374,8 +379,8 @@ func (s *sourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if !s.enabled {
 		if annotations.HasRequest(ann) && obj.GetDeletionTimestamp().IsZero() {
-			s.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, EventReasonKindNotEnabled,
-				actionMaterialize, "kind %s is not enabled for replication; enabled kinds: %s",
+			s.Recorder.Eventf(obj, corev1.EventTypeWarning, EventReasonKindNotEnabled,
+				"kind %s is not enabled for replication; enabled kinds: %s",
 				s.gvk.Kind, s.enabledKinds)
 		}
 		return ctrl.Result{}, nil
@@ -390,8 +395,8 @@ func (s *sourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Malformed contract: surface the exact parser message and keep any
 		// existing Replication untouched until the user fixes the typo —
 		// tearing down replicas over a syntax error would be destructive.
-		s.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, EventReasonInvalidAnnotations,
-			actionMaterialize, "%s", err.Error())
+		s.Recorder.Eventf(obj, corev1.EventTypeWarning, EventReasonInvalidAnnotations,
+			"%s", err.Error())
 		return ctrl.Result{}, nil
 	}
 	return ctrl.Result{}, s.materialize(ctx, obj, parsed)
@@ -458,8 +463,8 @@ func (s *sourceReconciler) materialize(ctx context.Context,
 		if len(denied) > 1 {
 			msg = fmt.Sprintf("%s (and %d more denied targets)", msg, len(denied)-1)
 		}
-		s.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, EventReasonPolicyDenied,
-			actionMaterialize, "%s", msg)
+		s.Recorder.Eventf(obj, corev1.EventTypeWarning, EventReasonPolicyDenied,
+			"%s", msg)
 	}
 
 	rep := &r8rv1alpha1.Replication{}
@@ -473,8 +478,7 @@ func (s *sourceReconciler) materialize(ctx context.Context,
 		rep = s.desiredReplication(obj, key.Name, resolved)
 		if err := s.Create(ctx, rep); err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				s.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, EventReasonNameConflict,
-					actionMaterialize,
+				s.Recorder.Eventf(obj, corev1.EventTypeWarning, EventReasonNameConflict,
 					"Replication %q already exists and is not owned by this %s; not materializing",
 					key.Name, s.gvk.Kind)
 				return nil
@@ -484,8 +488,7 @@ func (s *sourceReconciler) materialize(ctx context.Context,
 	case err != nil:
 		return err
 	case !s.ownedBySource(rep, obj.GetName()):
-		s.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, EventReasonNameConflict,
-			actionMaterialize,
+		s.Recorder.Eventf(obj, corev1.EventTypeWarning, EventReasonNameConflict,
 			"Replication %q already exists and is not owned by this %s; not materializing",
 			key.Name, s.gvk.Kind)
 		return nil

--- a/internal/controller/request/controller_test.go
+++ b/internal/controller/request/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package request
 
 import (
+	"slices"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -91,6 +92,24 @@ func eventsFor(ns, name string) func() []string {
 			}
 		}
 		return reasons
+	}
+}
+
+// operatorEventsFor returns the full Event objects recorded for the named
+// object, so tests can assert on more than the reason.
+func operatorEventsFor(ns, name string) func() []corev1.Event {
+	return func() []corev1.Event {
+		var list corev1.EventList
+		if err := k8sClient.List(ctx, &list, client.InNamespace(ns)); err != nil {
+			return nil
+		}
+		var out []corev1.Event
+		for _, e := range list.Items {
+			if e.InvolvedObject.Name == name {
+				out = append(out, e)
+			}
+		}
+		return out
 	}
 }
 
@@ -337,6 +356,56 @@ var _ = Describe("Request controller", func() {
 			Expect(k8sClient.Create(ctx, sec)).To(Succeed())
 			Eventually(eventsFor(ns, "broken"), timeout, interval).
 				Should(ContainElement(EventReasonInvalidAnnotations))
+		})
+	})
+
+	// Regression guard for issue #32: events recorded through the
+	// events.k8s.io/v1 recorder populate only eventTime, leaving
+	// firstTimestamp/lastTimestamp/count null after the API server's
+	// eventsv1 -> corev1 conversion. `kubectl get events
+	// --sort-by=.lastTimestamp` — the near-universal idiom — then sorts on a
+	// null key and returns an arbitrary order, which actively misleads
+	// whoever is reading the event log while debugging.
+	Context("event timestamps", func() {
+		It("populates lastTimestamp/firstTimestamp/count so --sort-by=.lastTimestamp orders correctly", func() {
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns, Name: "timestamped-sa",
+					Annotations: map[string]string{
+						annotations.KeyReplicate:      annotations.ValueTrue,
+						annotations.KeyTargetClusters: selectorProd,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sa)).To(Succeed())
+
+			var evs []corev1.Event
+			Eventually(func(g Gomega) {
+				evs = operatorEventsFor(ns, "timestamped-sa")()
+				g.Expect(evs).NotTo(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+
+			for _, e := range evs {
+				Expect(e.LastTimestamp.IsZero()).To(BeFalse(),
+					"event %s/%s has a null lastTimestamp; --sort-by=.lastTimestamp would misorder it",
+					e.Reason, e.Name)
+				Expect(e.FirstTimestamp.IsZero()).To(BeFalse(),
+					"event %s/%s has a null firstTimestamp", e.Reason, e.Name)
+				Expect(e.Count).To(BeNumerically(">=", 1),
+					"event %s/%s has a null count", e.Reason, e.Name)
+				Expect(e.LastTimestamp.Time).NotTo(BeTemporally("<", e.FirstTimestamp.Time))
+			}
+
+			// The sort key is not merely non-null but usable: sorting the
+			// recorded events by lastTimestamp yields a total, stable order.
+			sorted := slices.Clone(evs)
+			slices.SortFunc(sorted, func(a, b corev1.Event) int {
+				return a.LastTimestamp.Compare(b.LastTimestamp.Time)
+			})
+			for i := 1; i < len(sorted); i++ {
+				Expect(sorted[i-1].LastTimestamp.Time).
+					NotTo(BeTemporally(">", sorted[i].LastTimestamp.Time))
+			}
 		})
 	})
 

--- a/internal/engine/reconciler.go
+++ b/internal/engine/reconciler.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -160,7 +160,13 @@ type Reconciler struct {
 	// Scheme is the hub scheme.
 	Scheme *runtime.Scheme
 	// Recorder emits events on Replication objects; nil disables events.
-	Recorder events.EventRecorder
+	//
+	// This is deliberately the core/v1 recorder (client-go tools/record, i.e.
+	// manager.GetEventRecorderFor) and not the events.k8s.io one: only the
+	// core recorder populates firstTimestamp/lastTimestamp/count, which the
+	// universal `kubectl get events --sort-by=.lastTimestamp` idiom needs
+	// (issue #32).
+	Recorder record.EventRecorder
 	// Transport moves replicas to and from target clusters.
 	Transport Transport
 	// Clusters resolves discovery inventory (labels + gone detection).
@@ -849,7 +855,7 @@ func (r *Reconciler) event(rep *r8rv1alpha1.Replication, eventType, reason, mess
 	if r.limiter != nil && !r.limiter.Allow(string(rep.UID), reason, message) {
 		return
 	}
-	r.Recorder.Eventf(rep, nil, eventType, reason, "Reconcile", "%s", message)
+	r.Recorder.Eventf(rep, eventType, reason, "%s", message)
 }
 
 // emitTransitionEvents turns Ready-condition transitions into lifecycle

--- a/internal/engine/suite_test.go
+++ b/internal/engine/suite_test.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/events"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -320,7 +320,7 @@ type testFixture struct {
 	ns        string
 	transport *fakeTransport
 	clusters  *stubClusters
-	recorder  *events.FakeRecorder
+	recorder  *record.FakeRecorder
 	rec       *Reconciler
 	secret    *corev1.Secret
 	rep       *r8rv1alpha1.Replication
@@ -335,7 +335,7 @@ func newFixture(t *testing.T, secretValue string, targets []r8rv1alpha1.Resolved
 		t:         t,
 		transport: newFakeTransport(),
 		clusters:  newStubClusters(clusterNames...),
-		recorder:  events.NewFakeRecorder(200),
+		recorder:  record.NewFakeRecorder(200),
 	}
 
 	f.ns = uniqueName("eng-test")

--- a/internal/telemetry/events_rbac_audit_test.go
+++ b/internal/telemetry/events_rbac_audit_test.go
@@ -23,16 +23,28 @@ import (
 	"testing"
 )
 
-// Repo-level RBAC audit for event recording. The operator records events
-// through the events.k8s.io/v1 API (manager.GetEventRecorder →
-// client-go tools/events), so the manager's ClusterRole MUST grant
-// create/patch on events in the "events.k8s.io" API group — the core ""
-// group grant alone does not cover it. Without the grant every event write
-// is rejected with 403 and silently dropped by the recorder: reconciliation
-// keeps working, but lifecycle announcements (Replicated, ClusterGone,
-// PolicyRevoked, ...) never appear. This is exactly the failure mode that
-// broke the deregistration e2e test in CI, so this test ratchets the grant
-// into both RBAC sources.
+// Repo-level RBAC audit for event recording: the manager's ClusterRole MUST
+// grant create/patch on events in the "events.k8s.io" API group, in addition
+// to the core "" group grant.
+//
+// The operator currently records through the core/v1 recorder
+// (manager.GetEventRecorderFor → client-go tools/record), which only needs
+// the "" group — the events.k8s.io grant is retained deliberately, and this
+// test ratchets it into both RBAC sources so it cannot be dropped.
+//
+// Rationale: the events.k8s.io/v1 recorder (manager.GetEventRecorder →
+// client-go tools/events) writes to the "events.k8s.io" group, and a missing
+// grant there fails *silently* — every event write is rejected with 403 and
+// swallowed by the recorder, so reconciliation keeps working while lifecycle
+// announcements (Replicated, ClusterGone, PolicyRevoked, ...) simply never
+// appear. That failure mode once broke the deregistration e2e test in CI and
+// took real time to find. Keeping the grant means any future re-adoption of
+// the newer events API — deliberate or accidental, e.g. a scaffolding
+// regeneration — cannot silently regress into it.
+//
+// Do not remove this test or the grant "because we no longer use that API":
+// the grant is cheap, and its absence is expensive precisely because it is
+// invisible.
 func TestEventsV1RBACGrantPresent(t *testing.T) {
 	root := repoRoot(t)
 	for _, rel := range []string{
@@ -46,7 +58,8 @@ func TestEventsV1RBACGrantPresent(t *testing.T) {
 		}
 		if !hasEventsV1Rule(string(raw)) {
 			t.Errorf("%s: no RBAC rule grants create+patch on events in the events.k8s.io API group; "+
-				"the events.k8s.io/v1 recorder (mgr.GetEventRecorder) needs it or all operator events are dropped with 403", rel)
+				"the grant is kept deliberately so that any future switch back to the events.k8s.io/v1 recorder "+
+				"(mgr.GetEventRecorder) cannot silently drop every operator event with a 403", rel)
 		}
 	}
 }

--- a/obsidian/operations.md
+++ b/obsidian/operations.md
@@ -12,6 +12,8 @@ Replica desired/ready/failed gauges (per cluster) · policy/webhook denial count
 
 Lifecycle transitions on sources and Replications (Replicated, PolicyDenied, Conflict, PolicyRevoked, ClusterGone, CleanedUp), rate-limited per object+reason (5m cooldown, changed messages pass) so flapping targets can't flood. [[security-model|Never any payload data]].
 
+Recorded through the **core `v1` Event API** (`mgr.GetEventRecorderFor`), not `events.k8s.io/v1`: only the core recorder fills `firstTimestamp`/`lastTimestamp`/`count`, so `kubectl get events --sort-by=.lastTimestamp` orders them correctly and client-go's correlator aggregates repeats into a real count series. Trade-off: no `action` / `reportingController` fields. The `events.k8s.io` RBAC grant is kept regardless (a missing grant fails silently with 403), ratcheted by a repo audit test.
+
 ## Status discipline (D8)
 
 Summary counts + `Ready` condition; per-target detail only for non-ready targets, capped at 20 + overflow counter; status writes skipped when unchanged. 60-target e2e fanout: 13.9KB status, zero churn over 2 minutes. Full per-target truth lives in metrics/events.


### PR DESCRIPTION
Fixes #32.

## What

Both event recorders go back to the **core/v1** recorder (`mgr.GetEventRecorderFor` → `client-go/tools/record`) from the `events.k8s.io` one (`mgr.GetEventRecorder` → `client-go/tools/events`).

## Why

Proven in the dependency, not inferred:

- `client-go@v0.36.0/tools/events/event_recorder.go:97-112` — `makeEvent` sets **only** `EventTime`, leaving `DeprecatedFirstTimestamp` / `DeprecatedLastTimestamp` / `DeprecatedCount` zero. After the API server's `eventsv1 → corev1` conversion those surface as `null`.
- `client-go@v0.36.0/tools/record/event.go:502-504` sets `FirstTimestamp`, `LastTimestamp` and `Count`.

So `kubectl get events --sort-by=.lastTimestamp` — the near-universal idiom, and what most runbooks contain — sorted on a null key and returned an arbitrary order. During the staging trial that surfaced a stale `Replicated 0/0 targets ready` as the apparently-newest event while the object was healthy at `1/1`.

The issue's alternative suggestion — "set the legacy fields explicitly" — is **not available**: the `events.EventRecorder` interface exposes no hook for them. You would have to abandon the recorder and hand-write Event objects, losing the client-go correlator. It is revert-or-nothing.

## Trade-off, plainly

**Lost:** the `action` field (the request controller's `Materialize`, the engine's `Reconcile`) and `reportingController` / `reportingInstance`. The `actionMaterialize` constant is removed as dead.

**Gained:** the client-go `EventAggregator`/correlator, which produces real `count` / `firstTimestamp` / `lastTimestamp` series — repeats aggregate into a counted event instead of a flat stream of singletons. Arguably the better fit here: the operator's own `telemetry.EventLimiter` already handles steady-state repeat suppression, and the correlator complements it.

Event **reasons and message content are byte-identical** — they are covered by the AST secret-safety audit and by existing tests.

## RBAC is deliberately unchanged

Both `""` and `events.k8s.io` already grant `create`+`patch` in `config/rbac/role.yaml` and `charts/k8s-r8r/templates/rbac.yaml`. The `events.k8s.io` grant **stays**, and so does `internal/telemetry/events_rbac_audit_test.go`.

That test exists because a missing `events.k8s.io` grant once caused every operator event to be silently 403-dropped in-cluster (it broke the deregistration e2e test in CI, and took real time to find — reconciliation keeps working, the events just never appear). Removing the grant "because we no longer use that API" would re-arm exactly that trap for any future re-adoption of the newer API, deliberate or accidental.

Only the test's **rationale comment** changed: it now says the grant is retained deliberately as a guard against silent regression, rather than asserting the operator uses `GetEventRecorder`.

## Regression test

New envtest case in `internal/controller/request/controller_test.go` ("event timestamps"): it triggers a real operator event, then asserts against the **real API server** that every recorded `corev1.Event` has non-zero `firstTimestamp` and `lastTimestamp`, `count >= 1`, `lastTimestamp >= firstTimestamp`, and that sorting the recorded events by `lastTimestamp` yields a total order.

Verified both directions: the test **fails** with the `events.k8s.io` recorder restored and **passes** with this change. That is a real `--sort-by=.lastTimestamp` ordering exercised against an API server, not a mock.

## Note on the deprecation warning

`mgr.GetEventRecorderFor` is marked deprecated in controller-runtime (SA1019, "please use GetEventRecorder instead"). Two `//nolint:staticcheck` with the reason inline. This is the crux of the issue: the replacement API is the one that drops the timestamps. Worth revisiting only if upstream ever populates the legacy fields or `kubectl`'s default sort changes.

## Verification

- `make lint` — clean for every file this PR touches. Three pre-existing `SA5011` findings remain in `internal/annotations/annotations_test.go`; `main` at `160a017` fails the same way (plus one more in `internal/engine/reconciler_test.go`), so this branch is strictly no worse.
- `make test` — all packages pass.
- `make test-e2e` — **not run: docker daemon unavailable in this environment.** The e2e event helper (`test/e2e/framework.go:485`) reads `corev1.EventList` and filters on `involvedObject.name`, which the core recorder populates directly, so no e2e change was needed.

## Docs

`docs/quickstart.md` and `obsidian/operations.md` updated per the repo's docs-are-part-of-done contract. No OpenSpec change: `observability-operations/spec.md:23-28` says nothing about API group or timestamp fields.
