### PR TITLE
fix(engine): strip foreign ownership metadata from replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,31 @@ release; they are called out under **Changed** or **Removed**.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **`--strip-metadata-keys`** manager flag (chart value `stripMetadataKeys`)
+  extends the stripped-metadata denylist with fleet-specific keys.
+  Comma-separated and repeatable; a trailing `/` makes an entry a prefix
+  match. Additive only — built-in entries cannot be removed.
+
+### Fixed
+
+- **Replicas no longer inherit foreign ownership or replication metadata**
+  ([#26](https://github.com/moeritze/k8s-r8r/issues/26)). The engine now
+  strips `replicator.v1.mittwald.de/*`,
+  `reflector.v1.k8s.emberstack.com/*`, `argocd.argoproj.io/*`,
+  `app.kubernetes.io/instance`, `meta.helm.sh/*` and
+  `kustomize.toolkit.fluxcd.io/*` from replicas, and excludes them from the
+  source hash. Previously a replica of a source annotated for another
+  replication controller was itself a valid source for that controller, so
+  k8s-r8r seeded a second fanout whose destinations no `ReplicationPolicy`
+  evaluated; and a replica carrying ArgoCD's tracking label claimed
+  membership in an Application that never declared it, making it a prune
+  candidate. Existing replicas lose these keys on their next reconcile.
+  All other source metadata still propagates — this is a denylist scoped to
+  ownership, not an allowlist.
+- `docs/gitops.md` claimed "a normal Application will not prune them", which
+  was false under ArgoCD's default label-based resource tracking.
 
 ## [0.1.0-alpha.1] - 2026-08-24
 

--- a/charts/k8s-r8r/templates/deployment.yaml
+++ b/charts/k8s-r8r/templates/deployment.yaml
@@ -58,6 +58,9 @@ spec:
         - --discovery-provider={{ .Values.discoveryProvider }}
         - --hub-name={{ .Values.hubName }}
         - --allowed-kinds={{ join "," .Values.allowedKinds }}
+        {{- with .Values.stripMetadataKeys }}
+        - --strip-metadata-keys={{ join "," . }}
+        {{- end }}
         {{- with .Values.spokeResync }}
         - --spoke-resync={{ . }}
         {{- end }}

--- a/charts/k8s-r8r/values.yaml
+++ b/charts/k8s-r8r/values.yaml
@@ -43,6 +43,16 @@ allowedKinds:
   - secrets
   - configmaps
 
+# Additional label/annotation keys stripped from replicas and excluded from
+# the source hash (--strip-metadata-keys), on top of the built-in
+# foreign-ownership denylist (argocd.argoproj.io/, replicator.v1.mittwald.de/,
+# reflector.v1.k8s.emberstack.com/, meta.helm.sh/, kustomize.toolkit.fluxcd.io/
+# and app.kubernetes.io/instance). An entry ending in "/" is a prefix match;
+# anything else is an exact key. Additive only — built-in entries cannot be
+# removed, because removing them lets a replica become a source for another
+# replication controller.
+stripMetadataKeys: []
+
 # Drift resync interval for spoke informers and periodic reconciles
 # (--spoke-resync), as a Go duration, e.g. "1h". Empty uses the engine
 # default of 10h.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -112,6 +112,24 @@ func parseAllowedKinds(
 	return allowlist, kindGVKs, scope, nil
 }
 
+// stringListFlag is a flag.Value accumulating a list of strings: repeatable
+// and comma-separated, so --strip-metadata-keys=a,b and --strip-metadata-keys=a
+// --strip-metadata-keys=b are equivalent. Empty entries are dropped.
+type stringListFlag []string
+
+// String implements flag.Value.
+func (s *stringListFlag) String() string { return strings.Join(*s, ",") }
+
+// Set implements flag.Value.
+func (s *stringListFlag) Set(v string) error {
+	for part := range strings.SplitSeq(v, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			*s = append(*s, part)
+		}
+	}
+	return nil
+}
+
 // rotatingAuth is an http.RoundTripper that authenticates every request with
 // a currently valid short-lived ServiceAccount token from the Rotator, so a
 // spoke's clients stay authenticated across token refreshes without ever
@@ -286,6 +304,7 @@ func main() {
 	var discoveryProviderName string
 	var hubName string
 	var allowedKinds string
+	var stripMetadataKeys stringListFlag
 	var spokeResync time.Duration
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -311,6 +330,10 @@ func main() {
 		"The source-cluster identity stamped onto replicas.")
 	flag.StringVar(&allowedKinds, "allowed-kinds", "secrets,configmaps",
 		"Comma-separated resource names enabled for replication (supported: secrets, configmaps).")
+	flag.Var(&stripMetadataKeys, "strip-metadata-keys",
+		"Additional label/annotation keys stripped from replicas and excluded from the source hash, "+
+			"on top of the built-in foreign-ownership denylist. Comma-separated and repeatable; "+
+			"an entry ending in \"/\" is a prefix match. Additive only — built-in entries cannot be removed.")
 	flag.DurationVar(&spokeResync, "spoke-resync", 0,
 		"Drift resync interval for spoke informers and periodic reconciles (0 uses the engine default of 10h).")
 	opts := zap.Options{
@@ -326,6 +349,10 @@ func main() {
 		setupLog.Error(err, "Invalid --allowed-kinds")
 		os.Exit(1)
 	}
+
+	// Process-wide: the renderer and the canonical hash share one denylist,
+	// so this must be set before any reconciler runs.
+	engine.SetExtraStrippedKeys(stripMetadataKeys)
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -117,6 +117,41 @@ Request annotations themselves never propagate to replicas — all
 `r8r.io/*` keys are stripped before the engine's own metadata is applied,
 so a replica can never re-trigger replication.
 
+### Stripped metadata
+
+Beyond its own keys, the engine strips metadata that asserts **ownership
+by, or replication intent toward, another controller**. Such metadata is
+removed from the replica and excluded from the source hash, so source and
+replica still hash identically and drift detection is unaffected.
+
+| Stripped from replicas | Why |
+|---|---|
+| `replicator.v1.mittwald.de/*` | a replica carrying these is a valid *source* for mittwald/kubernetes-replicator — k8s-r8r would seed a second fanout no `ReplicationPolicy` evaluated |
+| `reflector.v1.k8s.emberstack.com/*` | same hazard, emberstack/kubernetes-reflector |
+| `argocd.argoproj.io/*` | ArgoCD resource tracking and sync options |
+| `app.kubernetes.io/instance` | ArgoCD's default (label) tracking key — a replica carrying it is an extraneous, prunable member of an Application that never declared it |
+| `meta.helm.sh/*` | Helm release ownership |
+| `kustomize.toolkit.fluxcd.io/*` | Flux kustomize-controller ownership |
+
+Everything else propagates unchanged. This is deliberately a **denylist,
+not an allowlist**: source metadata is often functionally significant on
+the target — a replicated sealed-secrets key without
+`sealedsecrets.bitnami.com/sealed-secrets-key: active` is inert on
+arrival — so dropping unknown keys by default would silently break
+working replications.
+
+Extend the list for controllers specific to your fleet:
+
+```sh
+--strip-metadata-keys=example.com/owner,vendor.example/
+```
+
+Comma-separated and repeatable. An entry ending in `/` is a prefix match;
+anything else is an exact key. The chart exposes it as
+`stripMetadataKeys` (a list). The flag is **additive only** — the built-in
+entries above cannot be removed, because removing them reintroduces the
+cross-controller fanout they exist to prevent.
+
 Finalizers used by the operator: `r8r.io/finalizer` on annotated sources
 and `r8r.io/engine-finalizer` on `Replication` objects — both exist so
 deletion waits for replica cleanup (see [uninstall.md](uninstall.md)).

--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -50,17 +50,61 @@ kubectl get secrets -A -l app.kubernetes.io/managed-by=k8s-r8r
 kubectl get secrets -A -l r8r.io/source-name=registry-creds,r8r.io/source-namespace=platform
 ```
 
+## Ownership metadata is not replicated
+
+ArgoCD decides what an Application owns from *resource tracking metadata*
+on the object itself: `app.kubernetes.io/instance` under the default
+label tracking, `argocd.argoproj.io/tracking-id` under annotation
+tracking. If that metadata were copied from a source onto its replicas,
+each replica would claim membership in an Application that never declared
+it, in a namespace and cluster outside that Application's spec — an
+extraneous object, and a prune candidate.
+
+So the engine strips ownership and replication-intent metadata before
+writing a replica, and excludes the same keys from the source hash:
+
+| Stripped | Owner |
+|---|---|
+| `argocd.argoproj.io/*` | ArgoCD resource tracking and sync options |
+| `app.kubernetes.io/instance` | ArgoCD label tracking (the default mode) |
+| `meta.helm.sh/*` | Helm release ownership |
+| `kustomize.toolkit.fluxcd.io/*` | Flux kustomize-controller ownership |
+| `replicator.v1.mittwald.de/*` | mittwald/kubernetes-replicator |
+| `reflector.v1.k8s.emberstack.com/*` | emberstack/kubernetes-reflector |
+
+Everything else on the source propagates unchanged — this is a denylist
+scoped to ownership, not an allowlist. Functionally significant labels
+have to survive the trip (see the sealed-secrets note below). Extend the
+list for controllers specific to your fleet with
+`--strip-metadata-keys` (chart value `stripMetadataKeys`, see
+[annotations.md](annotations.md#stripped-metadata)); it only adds — the
+built-in entries cannot be removed.
+
+The foreign-replicator entries matter beyond GitOps: a replica carrying
+`replicator.v1.mittwald.de/replicate-to-clusters` is itself a valid source
+for that controller, so without stripping k8s-r8r would seed a second
+fanout whose destinations no `ReplicationPolicy` ever evaluated. Running
+another replicator side by side is the realistic migration path onto
+k8s-r8r, so this is the configuration that matters most.
+
 ## Keeping ArgoCD's hands off replicas
 
 Replicas live outside git, so ArgoCD Applications that manage the target
 namespaces should not fight or prune them.
 
-**Pruning:** replicas are cluster-local objects ArgoCD did not create, so
-a normal Application will not prune them. Trouble only starts if an
-Application manages an object of the same name — then the two controllers
-will fight over content (k8s-r8r restores its payload on drift). Avoid
-overlapping names, or make one side the owner deliberately (see conflict
-policies in [policies.md](policies.md)).
+**Pruning:** a replica carries no ArgoCD tracking metadata (see above), so
+no Application claims it and none will prune it. Note that stripping is
+what makes this true — do not re-add `app.kubernetes.io/instance` to a
+replicated source expecting the replica to be exempt. Trouble still
+starts if an Application manages an object of the same name in a target
+namespace — then the two controllers fight over content (k8s-r8r restores
+its payload on drift). Avoid overlapping names, or make one side the owner
+deliberately (see conflict policies in [policies.md](policies.md)).
+
+Stamping replicas with `argocd.argoproj.io/compare-options:
+IgnoreExtraneous` is *not* an alternative: it suppresses the aggregate
+sync status but leaves the object pruneable. Removing the ownership claim
+is the durable fix.
 
 **Diffing:** if you mirror whole namespaces or use tooling that reports
 unmanaged objects, exclude operator-managed ones. Instance-wide resource

--- a/internal/engine/render.go
+++ b/internal/engine/render.go
@@ -33,6 +33,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -87,6 +88,66 @@ const (
 	r8rKeyPrefix = "r8r.io/"
 )
 
+// foreignOwnershipKeyPrefixes are key prefixes that assert ownership by, or
+// replication intent toward, another controller. They are stripped from
+// replicas and excluded from hashing (replication-engine spec, "Foreign
+// ownership metadata is not replicated").
+//
+// Copying them is not cosmetic. A replica carrying
+// replicator.v1.mittwald.de/replicate-to-clusters is itself a valid source for
+// mittwald/kubernetes-replicator, so k8s-r8r would seed a second fanout whose
+// destinations no ReplicationPolicy ever evaluated — a request-side override
+// of default-deny. The GitOps prefixes are the mirror hazard: a replica
+// claiming membership in an Application that never declared it is an
+// extraneous object, and prunable.
+var foreignOwnershipKeyPrefixes = []string{
+	"argocd.argoproj.io/",              // Argo CD tracking-id / sync options
+	"replicator.v1.mittwald.de/",       // mittwald/kubernetes-replicator
+	"reflector.v1.k8s.emberstack.com/", // emberstack/kubernetes-reflector
+	"meta.helm.sh/",                    // Helm release ownership
+	"kustomize.toolkit.fluxcd.io/",     // Flux kustomize-controller ownership
+}
+
+// foreignOwnershipKeys are exact keys stripped for the same reason. The Argo CD
+// instance label is the default resource-tracking key: a replica carrying it is
+// claimed by an Application that never declared it, and prunes with it.
+var foreignOwnershipKeys = []string{
+	"app.kubernetes.io/instance",
+}
+
+// extraStrippedKeys and extraStrippedPrefixes hold the operator's additions to
+// the built-in denylist (--strip-metadata-keys). They are process-wide rather
+// than Renderer fields because SourceHash is a package-level function: keeping
+// the render path and the hash path on one denylist is what prevents a replica
+// that never converges (see design D1/D4).
+var (
+	extraStrippedKeys     []string
+	extraStrippedPrefixes []string
+)
+
+// SetExtraStrippedKeys configures additional label/annotation keys to strip
+// from replicas and exclude from hashing, on top of the built-in denylist. An
+// entry ending in "/" is a prefix match; anything else is an exact key match.
+// Empty entries are ignored.
+//
+// The configuration is additive only — built-in entries cannot be removed,
+// since removing them reintroduces the cross-controller fanout the denylist
+// exists to prevent. Call once during startup, before any reconciler runs.
+func SetExtraStrippedKeys(keys []string) {
+	extraStrippedKeys = nil
+	extraStrippedPrefixes = nil
+	for _, k := range keys {
+		k = strings.TrimSpace(k)
+		switch {
+		case k == "" || k == "/":
+		case strings.HasSuffix(k, "/"):
+			extraStrippedPrefixes = append(extraStrippedPrefixes, k)
+		default:
+			extraStrippedKeys = append(extraStrippedKeys, k)
+		}
+	}
+}
+
 // serverManagedMetadataFields are the metadata fields stripped from replicas:
 // server-managed and identity fields that must never be copied across
 // clusters (replication-engine spec, "Kind-agnostic pipeline").
@@ -112,8 +173,12 @@ type Renderer struct {
 }
 
 // Render produces the replica for one target slot: a deep copy of the source
-// with server-managed fields stripped, engine identity labels applied, and
-// the source-hash annotation set. targetName overrides the replica name when
+// with server-managed fields and stripped metadata keys (isStrippedKey:
+// pipeline-owned keys plus foreign ownership metadata) removed, engine
+// identity labels applied, and the source-hash annotation set. All other
+// source labels and annotations propagate — they can be functionally
+// significant on the target, so this is a denylist, never an allowlist.
+// targetName overrides the replica name when
 // non-empty (the explicit r8r.io/target-name mechanism; automatic renaming
 // never occurs, design D7). The returned hash is SourceHash(src).
 func (r Renderer) Render(src *unstructured.Unstructured, targetNamespace, targetName string) (*unstructured.Unstructured, string) {
@@ -127,7 +192,7 @@ func (r Renderer) Render(src *unstructured.Unstructured, targetNamespace, target
 	}
 	rep.SetName(targetName)
 
-	labels := cleanPipelineKeys(rep.GetLabels())
+	labels := cleanStrippedKeys(rep.GetLabels())
 	if labels == nil {
 		labels = map[string]string{}
 	}
@@ -139,7 +204,7 @@ func (r Renderer) Render(src *unstructured.Unstructured, targetNamespace, target
 	labels[LabelSourceUID] = string(src.GetUID())
 	rep.SetLabels(labels)
 
-	ann := cleanPipelineKeys(rep.GetAnnotations())
+	ann := cleanStrippedKeys(rep.GetAnnotations())
 	if ann == nil {
 		ann = map[string]string{}
 	}
@@ -184,8 +249,9 @@ func (r Renderer) hubName() string {
 //   - status and all server-managed metadata (they differ per cluster),
 //   - metadata identity (name, namespace) so an explicitly renamed replica
 //     still hashes equal to its source and Adopt comparisons work,
-//   - every key the pipeline itself writes (r8r.io/*, the managed-by label,
-//     kubectl's last-applied annotation), so source and replica hash
+//   - every key stripped from replicas (isStrippedKey): the pipeline's own
+//     keys (r8r.io/*, the managed-by label, kubectl's last-applied
+//     annotation) and foreign ownership metadata, so source and replica hash
 //     identically.
 //
 // Determinism: the canonical form is Go's JSON encoding of the reduced
@@ -237,29 +303,57 @@ func stripServerManaged(obj *unstructured.Unstructured) {
 	}
 }
 
-// isPipelineKey reports whether a label/annotation key is written by the
-// replication pipeline itself and must therefore be stripped from replicas
-// (before re-adding current values) and excluded from hashing.
-func isPipelineKey(k string) bool {
-	return strings.HasPrefix(k, r8rKeyPrefix) || k == LabelManagedBy || k == annotationLastApplied
+// isStrippedKey reports whether a label/annotation key must be removed from
+// replicas (before the engine re-adds its own current values) and excluded
+// from hashing. Two disjoint reasons, one predicate:
+//
+//   - keys the replication pipeline itself writes (r8r.io/*, the managed-by
+//     label, kubectl's last-applied annotation), so request annotations never
+//     propagate to spokes and source and replica hash identically;
+//   - keys asserting another controller's ownership or replication intent,
+//     which must not travel with the payload.
+//
+// Both the render path (cleanStrippedKeys) and the hash path (cleanRawKeys)
+// route through here on purpose: a key stripped from the replica but retained
+// in the hash would make SourceHash(replica) != SourceHash(source) forever, so
+// the engine would re-apply on every reconcile and hot-loop against every
+// spoke through the drift handler.
+func isStrippedKey(k string) bool {
+	if strings.HasPrefix(k, r8rKeyPrefix) || k == LabelManagedBy || k == annotationLastApplied {
+		return true
+	}
+	if slices.Contains(foreignOwnershipKeys, k) || slices.Contains(extraStrippedKeys, k) {
+		return true
+	}
+	for _, p := range foreignOwnershipKeyPrefixes {
+		if strings.HasPrefix(k, p) {
+			return true
+		}
+	}
+	for _, p := range extraStrippedPrefixes {
+		if strings.HasPrefix(k, p) {
+			return true
+		}
+	}
+	return false
 }
 
-// cleanPipelineKeys returns a copy of m without pipeline-owned keys; nil in,
-// nil out.
-func cleanPipelineKeys(m map[string]string) map[string]string {
+// cleanStrippedKeys returns a copy of m without stripped keys; nil in, nil
+// out.
+func cleanStrippedKeys(m map[string]string) map[string]string {
 	if m == nil {
 		return nil
 	}
 	out := make(map[string]string, len(m))
 	for k, v := range m {
-		if !isPipelineKey(k) {
+		if !isStrippedKey(k) {
 			out[k] = v
 		}
 	}
 	return out
 }
 
-// cleanRawKeys is cleanPipelineKeys over the raw unstructured representation
+// cleanRawKeys is cleanStrippedKeys over the raw unstructured representation
 // of a string map.
 func cleanRawKeys(raw any) map[string]any {
 	m, ok := raw.(map[string]any)
@@ -268,7 +362,7 @@ func cleanRawKeys(raw any) map[string]any {
 	}
 	out := make(map[string]any, len(m))
 	for k, v := range m {
-		if !isPipelineKey(k) {
+		if !isStrippedKey(k) {
 			out[k] = v
 		}
 	}

--- a/internal/engine/render_test.go
+++ b/internal/engine/render_test.go
@@ -169,6 +169,149 @@ func TestSourceHash_IgnoresIdentityAndPipelineKeys(t *testing.T) {
 	}
 }
 
+// withMetadata returns a source Secret carrying key=value as both a label and
+// an annotation, so one table entry covers both maps.
+func withMetadata(key, value string) *unstructured.Unstructured {
+	src := testSecret()
+	md := src.Object["metadata"].(map[string]any)
+	md["labels"].(map[string]any)[key] = value
+	md["annotations"].(map[string]any)[key] = value
+	return src
+}
+
+// Spec "Foreign ownership metadata is not replicated": metadata asserting
+// another controller's ownership or replication intent never reaches a
+// replica. The mittwald case is the severe one — such a replica is a valid
+// source for that controller, so k8s-r8r would seed a second fanout whose
+// destinations no ReplicationPolicy evaluated.
+func TestRender_StripsForeignOwnershipMetadata(t *testing.T) {
+	cases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"mittwald replicate-to-clusters", "replicator.v1.mittwald.de/replicate-to-clusters", ".*"},
+		{"mittwald target-namespace", "replicator.v1.mittwald.de/target-namespace", "kube-system"},
+		{"emberstack reflector", "reflector.v1.k8s.emberstack.com/reflection-allowed", "true"},
+		{"argocd tracking-id", "argocd.argoproj.io/tracking-id", "some-app:/Secret:app/web-creds"},
+		{"argocd sync-options", "argocd.argoproj.io/sync-options", "Prune=false"},
+		{"argocd instance label", "app.kubernetes.io/instance", "some-app"},
+		{"helm release ownership", "meta.helm.sh/release-name", "platform"},
+		{"flux kustomize ownership", "kustomize.toolkit.fluxcd.io/name", "apps"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := withMetadata(tc.key, tc.value)
+			rep, hash := Renderer{}.Render(src, "target-ns", "")
+
+			if _, leaked := rep.GetLabels()[tc.key]; leaked {
+				t.Errorf("foreign ownership label %q leaked into replica", tc.key)
+			}
+			if _, leaked := rep.GetAnnotations()[tc.key]; leaked {
+				t.Errorf("foreign ownership annotation %q leaked into replica", tc.key)
+			}
+
+			// The stripped key must also be invisible to the hash, or the
+			// replica never converges (see below).
+			if hash != SourceHash(testSecret()) {
+				t.Errorf("stripped key %q changed the source hash", tc.key)
+			}
+		})
+	}
+}
+
+// Regression guard for the drift hot loop: stripping a key from the replica
+// while still hashing it on the source would make SourceHash(replica) differ
+// from the desired hash forever, so the engine would re-apply on every
+// reconcile, each apply would emit a metadata event, and the drift handler
+// would enqueue again — against every spoke.
+func TestSourceHash_StableAcrossForeignMetadataStripping(t *testing.T) {
+	src := testSecret()
+	md := src.Object["metadata"].(map[string]any)
+	md["labels"].(map[string]any)["app.kubernetes.io/instance"] = "some-app"
+	md["annotations"].(map[string]any)["replicator.v1.mittwald.de/replicate-to-clusters"] = ".*"
+	md["annotations"].(map[string]any)["argocd.argoproj.io/tracking-id"] = "some-app:/Secret:app/web-creds"
+
+	srcHash := SourceHash(src)
+	rep, renderedHash := Renderer{}.Render(src, "target-ns", "")
+	if renderedHash != srcHash {
+		t.Fatalf("rendered hash %s != source hash %s", renderedHash, srcHash)
+	}
+	if got := SourceHash(rep); got != srcHash {
+		t.Fatalf("replica re-hash %s != source hash %s: stripped keys still counted in the hash, "+
+			"which would make the engine re-apply on every reconcile", got, srcHash)
+	}
+}
+
+// The denylist must stay a denylist: functionally significant source metadata
+// has to keep propagating. A replicated sealed-secrets key without its
+// sealed-secrets-key label is inert on arrival.
+func TestRender_PropagatesFunctionalMetadata(t *testing.T) {
+	src := withMetadata("sealedsecrets.bitnami.com/sealed-secrets-key", "active")
+	src.Object["metadata"].(map[string]any)["labels"].(map[string]any)["app.kubernetes.io/name"] = "web"
+
+	rep, _ := Renderer{}.Render(src, "target-ns", "")
+	labels, ann := rep.GetLabels(), rep.GetAnnotations()
+
+	if labels["sealedsecrets.bitnami.com/sealed-secrets-key"] != "active" {
+		t.Error("sealed-secrets key label was stripped; the denylist must not become an allowlist")
+	}
+	if ann["sealedsecrets.bitnami.com/sealed-secrets-key"] != "active" {
+		t.Error("sealed-secrets annotation was stripped")
+	}
+	// app.kubernetes.io/instance is denied, but the rest of the recommended
+	// label set is not.
+	if labels["app.kubernetes.io/name"] != "web" {
+		t.Error("app.kubernetes.io/name was stripped; only the instance label is an ownership claim")
+	}
+	if labels["team"] != "web" || ann["note"] != "keep-me" {
+		t.Error("unrelated user metadata was lost")
+	}
+}
+
+// Spec scenario "Operator-configured additional keys": --strip-metadata-keys
+// extends the denylist for both the replica and the hash.
+func TestSetExtraStrippedKeys(t *testing.T) {
+	t.Cleanup(func() { SetExtraStrippedKeys(nil) })
+	SetExtraStrippedKeys([]string{"example.com/owner", "  ", "vendor.example/", "/"})
+
+	baseline := SourceHash(testSecret())
+
+	for _, key := range []string{"example.com/owner", "vendor.example/anything"} {
+		src := withMetadata(key, "x")
+		rep, hash := Renderer{}.Render(src, "target-ns", "")
+		if _, leaked := rep.GetLabels()[key]; leaked {
+			t.Errorf("configured key %q not stripped from replica labels", key)
+		}
+		if _, leaked := rep.GetAnnotations()[key]; leaked {
+			t.Errorf("configured key %q not stripped from replica annotations", key)
+		}
+		if hash != baseline {
+			t.Errorf("configured key %q changed the source hash", key)
+		}
+	}
+
+	// A near miss must not be stripped: "example.com/owner" is an exact key,
+	// not a prefix.
+	src := withMetadata("example.com/owner-extra", "x")
+	rep, _ := Renderer{}.Render(src, "target-ns", "")
+	if rep.GetLabels()["example.com/owner-extra"] != "x" {
+		t.Error("exact-key entry matched as a prefix")
+	}
+
+	// Clearing the configuration restores the built-in denylist only.
+	SetExtraStrippedKeys(nil)
+	mixed := withMetadata("example.com/owner", "x")
+	mixed.Object["metadata"].(map[string]any)["labels"].(map[string]any)["app.kubernetes.io/instance"] = "some-app"
+	rep, _ = Renderer{}.Render(mixed, "target-ns", "")
+	if rep.GetLabels()["example.com/owner"] != "x" {
+		t.Error("configured keys were not cleared")
+	}
+	if _, leaked := rep.GetLabels()["app.kubernetes.io/instance"]; leaked {
+		t.Error("built-in denylist entry disappeared with the configured ones")
+	}
+}
+
 func TestNamespacePayload(t *testing.T) {
 	ns := namespacePayload("fresh")
 	if ns.GetName() != "fresh" {

--- a/obsidian/replication-flow.md
+++ b/obsidian/replication-flow.md
@@ -29,6 +29,8 @@ Parsed by `internal/annotations` (shared with the [[security-model|webhook]]). D
 
 `internal/engine` reconciles each `Replication` per target (workqueue key = source + targetCluster; independent backoff):
 - payload stripped of server-managed fields, stamped with `app.kubernetes.io/managed-by: k8s-r8r`, source-ref labels, `r8r.io/source-hash: sha256:…`
+- **metadata hygiene**: foreign ownership / replication-intent keys are stripped too — `replicator.v1.mittwald.de/*`, `reflector.v1.k8s.emberstack.com/*`, `argocd.argoproj.io/*`, `app.kubernetes.io/instance`, `meta.helm.sh/*`, `kustomize.toolkit.fluxcd.io/*`, plus anything in `--strip-metadata-keys`. A replica carrying a foreign replicator's annotation would be a valid source for *that* controller, i.e. a fanout no [[policy-model|policy]] evaluated — the [[security-model|default-deny]] claim depends on this. Argo CD tracking keys are the mirror case: they make a replica prunable. Denylist, never an allowlist — a replicated sealed-secrets key must keep its own labels to work.
+- one predicate (`isStrippedKey`) feeds both the replica and the canonical hash. Stripping in only one of them would make `SourceHash(replica) != SourceHash(source)` forever → apply on every reconcile → [[drift-detection|drift]] event → enqueue → hot loop against every spoke.
 - applied via server-side apply (field manager `k8s-r8r`) over the push `Transport` using the spoke's [[security-model|bootstrapped SA token]]
 - conflicts with pre-existing unmanaged objects: `Fail` (default) / `Overwrite` (policy-gated) / `Adopt` (hash-equal only)
 - missing namespace: created only when policy sets `allowNamespaceCreation`; namespaces are never GC'd

--- a/openspec/changes/strip-foreign-ownership-metadata/.openspec.yaml
+++ b/openspec/changes/strip-foreign-ownership-metadata/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/strip-foreign-ownership-metadata/design.md
+++ b/openspec/changes/strip-foreign-ownership-metadata/design.md
@@ -1,0 +1,73 @@
+# Design — strip foreign ownership metadata
+
+## Context
+
+`internal/engine/render.go` has one predicate, `isPipelineKey`, feeding two
+consumers:
+
+- `cleanPipelineKeys` — the map used to build the replica in `Render`.
+- `cleanRawKeys` — the map used by `canonicalPayload`, i.e. the input to
+  `SourceHash`.
+
+Both must agree. `SourceHash` is deliberately identity-blind so a renamed,
+relocated replica hashes equal to its source; the engine's drift path
+(`reconciler.go`) compares `SourceHash(existing)` against the desired hash.
+
+## Decisions
+
+### D1 — Extend the predicate, not `Render`
+
+Stripping in `Render` alone would leave `canonicalPayload` hashing the source's
+original metadata. The replica, rendered without those keys, would then hash
+differently: `SourceHash(existing) != hash` would never converge, so the engine
+would apply on every reconcile, each apply would produce a metadata event, the
+drift handler would enqueue, and the result is a hot loop against every spoke.
+Routing everything through one predicate (renamed `isPipelineKey` →
+`isStrippedKey`, since it no longer means "keys the pipeline owns") makes that
+class of bug unrepresentable. A regression test asserts
+`SourceHash(source) == SourceHash(rendered)` with foreign keys present.
+
+### D2 — Denylist, not allowlist
+
+The issue suggested a `passthroughLabels` allowlist as the safer default. It is
+not: `render.go` deep-copies deliberately so functionally significant labels
+survive, and a replicated sealed-secrets key without
+`sealedsecrets.bitnami.com/sealed-secrets-key=active` is inert on arrival. An
+allowlist would break working replications on upgrade with no error surfaced.
+The hazard is specifically *ownership* metadata, so the denylist is scoped to
+that.
+
+### D3 — Strip rather than stamp for Argo CD
+
+`argocd.argoproj.io/compare-options: IgnoreExtraneous` suppresses the aggregate
+sync status but leaves `RequiresPruning` true, so it does not prevent the
+deletion. Stripping removes the claim of membership entirely and needs no
+cooperation from the target cluster's Argo CD configuration.
+
+### D4 — Package-level configuration for the extra keys
+
+`SourceHash` is a package-level function called from `reconciler.go` and
+`conflict.go`, not a `Renderer` method. Putting operator-configured keys on the
+`Renderer` struct would leave `SourceHash` unaware of them — exactly the
+desynchronisation D1 exists to prevent. The extra keys are therefore
+process-wide configuration: `engine.SetExtraStrippedKeys` is called once from
+`cmd/main.go` during flag processing, before any reconciler runs.
+
+Syntax: an entry ending in `/` is a prefix match, anything else is an exact key
+match — the same shape as the built-in list, and unambiguous without a second
+flag.
+
+The flag is additive only. Allowing removal of a built-in entry would let an
+operator reintroduce the cross-controller fanout, which is the hazard being
+fixed. An operator who genuinely needs `app.kubernetes.io/instance` on replicas
+has to re-add it by other means (it is on the built-in list because Argo CD
+label tracking prunes on it).
+
+## Risks
+
+- **Visible change on upgrade.** Replicas that carry these keys today lose them
+  on the next reconcile. The hash changes with them, so the apply happens once
+  and then converges. Called out in the CHANGELOG.
+- **The denylist is a moving target.** New replication controllers will appear.
+  That is what `--strip-metadata-keys` is for; adding a widely used controller
+  to the built-in list later is a normal follow-up change.

--- a/openspec/changes/strip-foreign-ownership-metadata/proposal.md
+++ b/openspec/changes/strip-foreign-ownership-metadata/proposal.md
@@ -1,0 +1,85 @@
+# Strip foreign ownership metadata from replicas
+
+## Why
+
+`Renderer.Render` deep-copies the source object's labels and annotations and
+strips only the keys the pipeline itself owns (`r8r.io/*`, the managed-by
+label, kubectl's last-applied annotation). Every other controller's ownership
+and replication metadata therefore rides along onto every replica, with two
+consequences observed on a live hub/spoke pair (issue #26):
+
+1. A replica carrying `replicator.v1.mittwald.de/replicate-to-clusters: ".*"`
+   is a valid *source* for mittwald/kubernetes-replicator. If any target
+   cluster runs that controller, k8s-r8r seeds a second, independent fanout
+   from its own output, with the foreign controller's regex — not a
+   `ReplicationPolicy` — deciding where the secret material goes next. That is
+   a request-side override of default-deny, which the security model states
+   does not exist.
+2. A replica carrying Argo CD's tracking metadata (`app.kubernetes.io/instance`
+   under the default label tracking, `argocd.argoproj.io/tracking-id` under
+   annotation tracking) claims membership in an Application that never declared
+   it, in a namespace and cluster outside that Application's spec. Argo CD
+   reads it as extraneous, and with automated pruning enabled the replica
+   becomes a deletion candidate — silent data loss.
+
+This is an undocumented gap, not a violated requirement: the existing
+"Kind-agnostic pipeline" requirement (`replication-engine/spec.md:21`) names
+only server-managed and identity fields; foreign ownership metadata was never
+mentioned either way. This change closes the gap by making the behavior
+normative.
+
+## What Changes
+
+- The engine strips a denylist of foreign ownership / replication-intent keys
+  from replicas — currently the prefixes `argocd.argoproj.io/`,
+  `replicator.v1.mittwald.de/`, `reflector.v1.k8s.emberstack.com/`,
+  `meta.helm.sh/`, `kustomize.toolkit.fluxcd.io/` and the exact key
+  `app.kubernetes.io/instance`.
+- The same keys are excluded from the canonical source hash, so a source and
+  its replica keep hashing identically and drift detection does not see a
+  permanent mismatch.
+- The denylist is additively extensible by the operator via a new
+  `--strip-metadata-keys` manager flag (chart value `stripMetadataKeys`).
+  It only adds; the built-in entries cannot be removed, since removing them
+  would reintroduce the fanout hazard.
+- Deliberately **not** an allowlist: functionally significant source labels
+  must keep propagating (a replicated sealed-secrets key is inert on arrival
+  without `sealedsecrets.bitnami.com/sealed-secrets-key=active`). This stays a
+  denylist scoped to *ownership* metadata.
+- Deliberately **not** stamping `argocd.argoproj.io/compare-options:
+  IgnoreExtraneous` on replicas: it suppresses aggregate sync status but leaves
+  `RequiresPruning` true, so it does not prevent the deletion this change is
+  about.
+- Docs: correct the false pruning claim in `docs/gitops.md`, document the
+  stripped keys and the flag in `docs/annotations.md`, update
+  `obsidian/replication-flow.md`, add a CHANGELOG entry.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `replication-engine`: adds a requirement covering foreign ownership and
+  replication-intent metadata on replicas (stripping plus hash exclusion).
+
+## Impact
+
+- `internal/engine/render.go` — `isPipelineKey` becomes `isStrippedKey` and
+  gains the foreign-key denylist plus the operator-configured additions; both
+  `cleanPipelineKeys` and `cleanRawKeys` (the hash path) route through it, so
+  replica rendering and hashing stay consistent.
+- `internal/engine/render_test.go` — table coverage per stripped prefix/key, a
+  hash-stability regression test (`SourceHash(source) == SourceHash(rendered)`
+  with foreign keys present), and a test that unrelated metadata still
+  propagates.
+- `cmd/main.go` — `--strip-metadata-keys` flag, parsed and handed to the engine
+  package before the manager starts.
+- `charts/k8s-r8r/values.yaml`, `charts/k8s-r8r/templates/deployment.yaml` —
+  `stripMetadataKeys` value rendered as the flag.
+- `docs/gitops.md`, `docs/annotations.md`, `obsidian/replication-flow.md`,
+  `CHANGELOG.md`.
+- Behavior change for existing installations: replicas that today carry these
+  keys lose them on the next reconcile. That is the fix, but it is visible.

--- a/openspec/changes/strip-foreign-ownership-metadata/specs/replication-engine/spec.md
+++ b/openspec/changes/strip-foreign-ownership-metadata/specs/replication-engine/spec.md
@@ -1,0 +1,41 @@
+# replication-engine
+
+## ADDED Requirements
+
+### Requirement: Foreign ownership metadata is not replicated
+Labels and annotations on a source object that assert ownership by, or
+replication intent toward, a controller other than k8s-r8r SHALL NOT be copied
+onto replicas, and SHALL be excluded from the canonical source hash so that a
+source and its replica hash identically.
+
+The stripped set SHALL cover, at minimum, the key prefixes
+`argocd.argoproj.io/`, `replicator.v1.mittwald.de/`,
+`reflector.v1.k8s.emberstack.com/`, `meta.helm.sh/`,
+`kustomize.toolkit.fluxcd.io/` and the exact key `app.kubernetes.io/instance`.
+The operator SHALL be able to extend this set with additional keys or prefixes
+at deployment time; the built-in entries SHALL NOT be removable.
+
+Stripping SHALL be scoped to ownership and replication-intent metadata: all
+other source labels and annotations continue to propagate, because they can be
+functionally significant on the target (for example a sealed-secrets key
+label).
+
+#### Scenario: Foreign replicator annotation on the source
+- **WHEN** a source Secret carries `replicator.v1.mittwald.de/replicate-to-clusters: ".*"` and is replicated
+- **THEN** the replica carries no `replicator.v1.mittwald.de/*` key, so it is not itself a valid source for that controller and cannot seed a fanout no `ReplicationPolicy` evaluated
+
+#### Scenario: GitOps tracking label on the source
+- **WHEN** a source Secret carries the Argo CD tracking label `app.kubernetes.io/instance: some-app` and is replicated
+- **THEN** the replica carries no `app.kubernetes.io/instance` label and no `argocd.argoproj.io/*` key, so it does not claim membership in an Application and is not a prune candidate on the target cluster
+
+#### Scenario: Hash stability with foreign keys present
+- **WHEN** the engine hashes a source that carries stripped keys and hashes the replica rendered from it
+- **THEN** both hashes are equal, so the replica is not re-applied on every reconcile
+
+#### Scenario: Unrelated source metadata still propagates
+- **WHEN** a source Secret carries metadata outside the stripped set, such as `sealedsecrets.bitnami.com/sealed-secrets-key: active`
+- **THEN** that metadata appears unchanged on the replica
+
+#### Scenario: Operator-configured additional keys
+- **WHEN** the operator configures additional metadata keys or key prefixes to strip
+- **THEN** those keys are stripped from replicas and excluded from the hash in addition to the built-in set

--- a/openspec/changes/strip-foreign-ownership-metadata/tasks.md
+++ b/openspec/changes/strip-foreign-ownership-metadata/tasks.md
@@ -1,0 +1,45 @@
+# Tasks — strip foreign ownership metadata
+
+## 1. Engine
+
+- [x] 1.1 Rename `isPipelineKey` to `isStrippedKey` and extend it with the
+      foreign-ownership denylist (prefixes `argocd.argoproj.io/`,
+      `replicator.v1.mittwald.de/`, `reflector.v1.k8s.emberstack.com/`,
+      `meta.helm.sh/`, `kustomize.toolkit.fluxcd.io/`; exact key
+      `app.kubernetes.io/instance`), keeping `cleanPipelineKeys` and
+      `cleanRawKeys` on the same predicate so replica and hash agree.
+- [x] 1.2 Add `SetExtraStrippedKeys` for operator-configured additions
+      (trailing `/` = prefix, otherwise exact key), additive only.
+
+## 2. Flag plumbing
+
+- [x] 2.1 Add the `--strip-metadata-keys` flag in `cmd/main.go` (comma-separated,
+      repeatable) and call `engine.SetExtraStrippedKeys` before manager start.
+- [x] 2.2 Add the `stripMetadataKeys` chart value and render it as the flag in
+      the deployment template.
+
+## 3. Tests
+
+- [x] 3.1 Table test over each stripped prefix/exact key on labels and
+      annotations of a source Secret.
+- [x] 3.2 Regression test: `SourceHash(source) == SourceHash(rendered)` with
+      foreign keys present (guards the drift hot-loop).
+- [x] 3.3 Test that unrelated metadata (e.g. the sealed-secrets key label)
+      still propagates — the denylist must not become an allowlist.
+- [x] 3.4 Test `SetExtraStrippedKeys` for both exact and prefix entries,
+      including hash exclusion.
+
+## 4. Docs
+
+- [x] 4.1 `docs/gitops.md`: correct the false "a normal Application will not
+      prune them" claim and describe the stripping behavior.
+- [x] 4.2 `docs/annotations.md`: document stripped foreign metadata and the
+      flag under operator-written metadata.
+- [x] 4.3 `obsidian/replication-flow.md`: note metadata hygiene in the fanout
+      step.
+- [x] 4.4 `CHANGELOG.md`: entry under Unreleased (Fixed + Added).
+
+## 5. Verification
+
+- [ ] 5.1 `make lint && make test`.
+- [ ] 5.2 `make test-e2e` if docker is available.


### PR DESCRIPTION
Fixes #26

## Problem

`Renderer.Render` deep-copied every source label and annotation except the pipeline's own keys (`r8r.io/*`, the managed-by label, kubectl's last-applied annotation), so **any other controller's ownership or replication metadata rode along onto every replica**.

The severe half is not the GitOps interop. A replica carrying `replicator.v1.mittwald.de/replicate-to-clusters: ".*"` is, verbatim, a valid *source* for mittwald/kubernetes-replicator. On a fleet running both controllers — the realistic migration path onto k8s-r8r — k8s-r8r handed secret material to a second, independent fanout whose destinations **no `ReplicationPolicy` ever evaluated**. That is a request-side override of default-deny, which the security model states does not exist.

The GitOps half is the mirror case: a replica carrying `app.kubernetes.io/instance` (Argo CD's default label tracking) or `argocd.argoproj.io/tracking-id` claims membership in an Application that never declared it, in a namespace and cluster outside that Application's spec — an extraneous object, and with automated pruning a deletion candidate.

## Fix

`isPipelineKey` becomes `isStrippedKey` and gains a denylist:

| Stripped | Owner |
|---|---|
| `replicator.v1.mittwald.de/*` | mittwald/kubernetes-replicator |
| `reflector.v1.k8s.emberstack.com/*` | emberstack/kubernetes-reflector |
| `argocd.argoproj.io/*` | Argo CD tracking / sync options |
| `app.kubernetes.io/instance` | Argo CD label tracking (the default mode) |
| `meta.helm.sh/*` | Helm release ownership |
| `kustomize.toolkit.fluxcd.io/*` | Flux kustomize-controller ownership |

**Why the one predicate matters.** Both the render path (`cleanStrippedKeys`) and the hash path (`cleanRawKeys` → `canonicalPayload` → `SourceHash`) route through `isStrippedKey`. Stripping in `Render` alone would leave the hash covering the source's original metadata: `SourceHash(existing) != hash` would never converge, so the engine would apply on every reconcile, each apply would emit a metadata event, the drift handler would enqueue, and the result is a hot loop against every spoke. `TestSourceHash_StableAcrossForeignMetadataStripping` ratchets that shut.

**Denylist, deliberately not an allowlist.** `render.go` deep-copies so functionally significant labels survive; a replicated sealed-secrets key without `sealedsecrets.bitnami.com/sealed-secrets-key: active` is inert on arrival. A `passthrough` allowlist would break working replications on upgrade with nothing surfaced. `TestRender_PropagatesFunctionalMetadata` covers that, including that `app.kubernetes.io/name` survives while only the `instance` ownership claim is dropped.

**Not stamping `argocd.argoproj.io/compare-options: IgnoreExtraneous`.** It suppresses the aggregate sync status but leaves `RequiresPruning` true, so it does not prevent the deletion. Removing the ownership claim is the durable fix.

## Extensibility

`--strip-metadata-keys` (chart value `stripMetadataKeys`) adds fleet-specific keys. Comma-separated and repeatable; a trailing `/` makes an entry a prefix match. **Additive only** — built-in entries cannot be removed, since removing one reintroduces the cross-controller fanout.

It is process-wide configuration (`engine.SetExtraStrippedKeys`, called once from `cmd/main.go`) rather than a `Renderer` field because `SourceHash` is a package-level function called from `reconciler.go` and `conflict.go`; putting the keys on the struct would leave the hash path unaware of them — exactly the desynchronisation above.

## Spec

`openspec/changes/strip-foreign-ownership-metadata` adds a `replication-engine` requirement, *Foreign ownership metadata is not replicated*, with scenarios for the foreign-replicator annotation, the GitOps tracking label, hash stability, continued propagation of unrelated metadata, and operator-configured keys.

This closes a **gap**, not a violation: the existing "Kind-agnostic pipeline" requirement (`replication-engine/spec.md:21`) named only server-managed and identity fields and never mentioned foreign ownership metadata either way.

## Upgrade note

Replicas that carry these keys today lose them on their next reconcile. The hash changes with them, so the apply happens once and then converges. Called out in the CHANGELOG.

## Verification

- `make lint` — no new findings. Four pre-existing `staticcheck` SA5011 findings in `internal/engine/reconciler_test.go` (untouched here) reproduce on `origin/main`.
- `make test` — all packages pass; `internal/engine` at 80.3% coverage.
- `helm lint` + `helm template` with and without `stripMetadataKeys` — flag renders only when set.
- `make test-e2e` **not run**: the Docker daemon is not reachable in this environment. This is an engine change, so e2e is worth running before merge.

## Docs (in this PR)

- `docs/gitops.md` — the claim *"replicas are cluster-local objects ArgoCD did not create, so a normal Application will not prune them"* was **false under label tracking**. Corrected, plus a new "Ownership metadata is not replicated" section.
- `docs/annotations.md` — new "Stripped metadata" section covering the denylist and the flag.
- `obsidian/replication-flow.md` — metadata hygiene in the fanout step.
- `CHANGELOG.md` — entry under Unreleased.
