### PR TITLE
fix(discovery): negotiate the served CAPI Cluster API version

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -456,6 +456,18 @@ func main() {
 	wirer := newSpokeWirer(ctx, mgr.GetAPIReader(), clusterManager, rbacScope)
 	provider.Subscribe(wirer.Handle)
 
+	// Discovery-health metrics, sourced from the provider itself at scrape
+	// time. k8s_r8r_clusters counts registered *runtimes* and reads 0 both
+	// when discovery is broken and when the fleet is empty;
+	// k8s_r8r_discovery_up separates the two.
+	telemetry.SetDiscoverySnapshot(func() telemetry.DiscoveryState {
+		return telemetry.DiscoveryState{
+			Provider: provider.Name(),
+			Up:       provider.Watching(),
+			Clusters: len(provider.List()),
+		}
+	})
+
 	// Cluster connectivity + runtime-count metrics, sourced from the
 	// runtime manager's snapshot at scrape time (0 unreachable, 1 degraded,
 	// 2 reachable).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -59,6 +59,26 @@ demonstrates the entire hub-side flow — request materialization, the
 default-deny policy decision, and status/events — with the target list
 resolving to zero clusters.
 
+> **Troubleshooting — zero clusters discovered.** The operator does not pin
+> a CAPI API version: it negotiates one of `v1`, `v1beta2`, `v1beta1` from
+> the hub's discovery API at startup and logs the result. If nothing
+> replicates and target lists are empty, check the negotiated version first:
+>
+> ```sh
+> kubectl -n k8s-r8r-system logs deploy/k8s-r8r | grep -i 'ClusterAPI'
+> ```
+>
+> `Negotiated ClusterAPI discovery version groupVersion=...` means discovery
+> is fine. `ClusterAPI inventory unavailable, retrying` means the hub has no
+> `clusters.cluster.x-k8s.io` (the expected state on a bare kind fleet, as
+> above) — the operator waits and picks it up when ClusterAPI is installed.
+> `serves none of [...]` means the hub's CAPI serves only versions this build
+> does not support; the pod restarts with that message until you upgrade.
+> The `k8s_r8r_discovery_up` metric carries the same signal: `0` means
+> discovery is not running, `1` with `k8s_r8r_discovery_clusters=0` means a
+> genuinely empty fleet. Note the pod stays **Ready** in all these cases —
+> readiness reflects hub informer sync only, by design.
+
 ## 2. Build and install the operator on the hub
 
 ```sh

--- a/internal/discovery/capi/provider.go
+++ b/internal/discovery/capi/provider.go
@@ -1,7 +1,29 @@
 // Package capi implements the ClusterAPI discovery provider.
 //
-// It watches ClusterAPI Cluster objects (cluster.x-k8s.io/v1beta1) on the hub
-// and translates them into discovery.ClusterRecords:
+// It watches ClusterAPI Cluster objects on the hub and translates them into
+// discovery.ClusterRecords.
+//
+// # API version negotiation
+//
+// The watched version is NOT pinned. On Start the provider asks the hub's
+// discovery API which versions of clusters.cluster.x-k8s.io are served and
+// picks the first entry of supportedClusterVersions ("v1", "v1beta2",
+// "v1beta1", most preferred first) that appears there, logging the choice
+// once. CAPI moved its storage version to v1beta2 and schedules v1beta1
+// unserved in 1.16; a pinned GVR would then wedge the informer in an endless
+// 404 retry and report an empty fleet. When the resource IS served but at no
+// supported version, the provider fails to start with an error naming the
+// group/resource and the versions the server does serve — a loud, named
+// failure instead of a silently empty inventory. When the resource is not
+// served at all (ClusterAPI not installed, or installed after the operator)
+// the provider retries instead, reporting itself as not watching so
+// k8s_r8r_discovery_up reads 0 while it waits.
+//
+// The explicit list is deliberate: the group's preferredVersion would
+// auto-adopt any future CAPI version, including one whose readiness
+// condition vocabulary this provider has never been validated against.
+//
+// Records are built as:
 //
 //   - Name: the Cluster object's metadata.name (stable for the object's
 //     lifetime). Fleets that run identically named Clusters in multiple
@@ -25,16 +47,21 @@ package capi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sdiscovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/moeritze/k8s-r8r/internal/discovery"
 )
@@ -47,12 +74,31 @@ const ProviderName = "cluster-api"
 // Empty (the default) watches all namespaces.
 const SettingNamespace = "namespace"
 
-// clusterGVR identifies ClusterAPI Cluster objects.
-var clusterGVR = schema.GroupVersionResource{
+// clusterGroupResource identifies ClusterAPI Cluster objects; the version is
+// negotiated at Start (see resolveClusterGVR).
+var clusterGroupResource = schema.GroupResource{
 	Group:    "cluster.x-k8s.io",
-	Version:  "v1beta1",
 	Resource: "clusters",
 }
+
+// supportedClusterVersions are the cluster.x-k8s.io versions this provider is
+// validated against, most preferred first. The list is explicit rather than
+// derived from the group's preferredVersion so that the versions whose
+// readiness-condition vocabulary we understand (see readyConditionTypes) stay
+// an auditable constant: a future CAPI version is adopted by a reviewed
+// one-line change, never silently.
+var supportedClusterVersions = []string{"v1", "v1beta2", "v1beta1"}
+
+// cacheSyncTimeout bounds the initial informer sync. Without it a reflector
+// retrying a retryable error (a 404 on an unserved version, a missing RBAC
+// rule) blocks Start until process shutdown, turning a misconfiguration into
+// a silent hang.
+const cacheSyncTimeout = 2 * time.Minute
+
+// negotiateRetry is how long the provider waits before re-asking the
+// discovery API after a retryable failure (hub unreachable, ClusterAPI not
+// installed yet).
+const negotiateRetry = 30 * time.Second
 
 // kubeconfigSecretSuffix is the ClusterAPI convention for the admin
 // kubeconfig Secret name.
@@ -60,7 +106,13 @@ const kubeconfigSecretSuffix = "-kubeconfig"
 
 // readyConditionTypes are the condition types (any one with status "True")
 // that gate readiness: ControlPlaneReady is the v1beta1 condition,
-// ControlPlaneAvailable its v1beta2 successor surfaced on v1beta1 objects.
+// ControlPlaneAvailable its successor in the v1beta2 condition set. Both are
+// accepted because either can be what .status.conditions carries, depending
+// on the negotiated version and on which condition set the CAPI release
+// promotes there — which is what keeps readiness evaluation independent of
+// the version this provider negotiates. Both shapes expose "type" and
+// "status" as strings at the same path, so controlPlaneReady reads them
+// generically.
 var readyConditionTypes = map[string]struct{}{
 	"ControlPlaneReady":     {},
 	"ControlPlaneAvailable": {},
@@ -75,7 +127,17 @@ func init() {
 		if err != nil {
 			return nil, fmt.Errorf("capi: building dynamic client: %w", err)
 		}
-		return New(dyn, WithNamespace(o.Setting(SettingNamespace, ""))), nil
+		// The discovery client is built here but only *used* in Start:
+		// construction happens before the manager's lifecycle exists, so a
+		// hub that is briefly unreachable must not crash-loop the factory.
+		disco, err := k8sdiscovery.NewDiscoveryClientForConfig(o.HubConfig)
+		if err != nil {
+			return nil, fmt.Errorf("capi: building discovery client: %w", err)
+		}
+		return New(dyn,
+			WithDiscovery(disco),
+			WithNamespace(o.Setting(SettingNamespace, "")),
+		), nil
 	})
 }
 
@@ -92,9 +154,17 @@ func WithResync(d time.Duration) Option {
 	return func(p *Provider) { p.resync = d }
 }
 
+// WithDiscovery sets the discovery client used to negotiate the served
+// cluster.x-k8s.io version. It is required: Start fails without one rather
+// than falling back to a guessed version.
+func WithDiscovery(d k8sdiscovery.DiscoveryInterface) Option {
+	return func(p *Provider) { p.disco = d }
+}
+
 // Provider watches ClusterAPI Cluster objects and emits discovery events.
 type Provider struct {
 	dyn       dynamic.Interface
+	disco     k8sdiscovery.DiscoveryInterface
 	namespace string
 	resync    time.Duration
 
@@ -102,6 +172,11 @@ type Provider struct {
 	handlers []discovery.EventHandler
 	// records is keyed by "namespace/name" of the Cluster object.
 	records map[string]discovery.ClusterRecord
+	// watching reports whether the Cluster informer is established and
+	// synced. It is the source of the discovery-health gauge: it
+	// distinguishes "the provider is not running" from "the provider runs
+	// and the fleet is empty".
+	watching bool
 }
 
 // New builds a Provider on top of a dynamic client.
@@ -138,25 +213,197 @@ func (p *Provider) List() []discovery.ClusterRecord {
 	return out
 }
 
-// Start implements discovery.Provider. It runs the Cluster informer and
-// blocks until ctx is done.
+// Watching implements discovery.Provider: it reports whether the Cluster
+// informer is established and synced. It is the provider's own health
+// signal — false means discovery is not
+// running at all, which is what distinguishes a broken provider from a
+// genuinely empty fleet (both otherwise show zero clusters).
+func (p *Provider) Watching() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.watching
+}
+
+// Start implements discovery.Provider. It negotiates the served Cluster API
+// version, runs the Cluster informer, and blocks until ctx is done.
+//
+// Version negotiation happens here rather than at construction so a hub that
+// is unreachable at process start is retried through the manager's lifecycle
+// instead of crash-looping the factory. Two failure modes are deliberately
+// separated:
+//
+//   - The Cluster resource exists but serves no supported version. Start
+//     returns errUnsupportedVersions before the informer is created. As a
+//     manager Runnable that stops the manager and restarts the pod with the
+//     reason in its logs, which is the right answer to a structural
+//     incompatibility between this build and the hub that will not resolve
+//     itself. (This is unrelated to readiness, which stays hub-cache-only:
+//     one unreachable spoke must never make the operator unready, but an
+//     unusable inventory *source* is not one spoke.)
+//   - The Cluster resource is absent, or the hub is unreachable. Both may
+//     resolve on their own — ClusterAPI installed later, an API server
+//     restarting — so Start retries instead of failing, and reports itself
+//     as not watching (k8s_r8r_discovery_up == 0) with the reason logged
+//     while it waits.
 func (p *Provider) Start(ctx context.Context) error {
+	gvr, err := p.negotiate(ctx)
+	if err != nil {
+		return err
+	}
+	if gvr.Empty() {
+		// Stopped while waiting for the Cluster resource to appear.
+		return nil
+	}
+	log.FromContext(ctx).Info("Negotiated ClusterAPI discovery version",
+		"groupVersion", gvr.GroupVersion().String(), "resource", gvr.Resource)
+
 	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(p.dyn, p.resync, p.namespace, nil)
-	informer := factory.ForResource(clusterGVR).Informer()
-	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	informer := factory.ForResource(gvr).Informer()
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    p.upsert,
 		UpdateFunc: func(_, newObj any) { p.upsert(newObj) },
 		DeleteFunc: p.remove,
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("capi: adding informer handler: %w", err)
 	}
 	factory.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
-		return fmt.Errorf("capi: cluster informer cache never synced")
+
+	syncCtx, cancelSync := context.WithTimeout(ctx, cacheSyncTimeout)
+	defer cancelSync()
+	if !cache.WaitForCacheSync(syncCtx.Done(), informer.HasSynced) {
+		if ctx.Err() != nil {
+			// Shutdown during the initial sync is not a failure.
+			return nil
+		}
+		return fmt.Errorf("capi: %s informer cache never synced within %s",
+			gvr.GroupResource(), cacheSyncTimeout)
 	}
+
+	p.setWatching(true)
+	defer p.setWatching(false)
 	<-ctx.Done()
 	return nil
+}
+
+func (p *Provider) setWatching(v bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.watching = v
+}
+
+// negotiate resolves the Cluster GVR, retrying the conditions that can
+// resolve themselves (hub unreachable, Cluster CRD not installed yet) and
+// returning the ones that cannot (no supported version served). It returns
+// an empty GVR and a nil error when ctx ends while it is still waiting, so
+// shutdown is not reported as a failure.
+func (p *Provider) negotiate(ctx context.Context) (schema.GroupVersionResource, error) {
+	var zero schema.GroupVersionResource
+	logger := log.FromContext(ctx)
+	for {
+		gvr, err := resolveClusterGVR(p.disco)
+		switch {
+		case err == nil:
+			return gvr, nil
+		case errors.Is(err, errUnsupportedVersions), errors.Is(err, errNoDiscoveryClient):
+			return zero, err
+		}
+		// Retryable: the resource may appear (ClusterAPI installed after
+		// the operator) or the hub may come back. Not silent — the reason
+		// is logged and Watching() stays false, so k8s_r8r_discovery_up
+		// reads 0 for as long as this lasts.
+		logger.Error(err, "ClusterAPI inventory unavailable, retrying",
+			"resource", clusterGroupResource.String(), "retryAfter", negotiateRetry)
+		select {
+		case <-ctx.Done():
+			return zero, nil
+		case <-time.After(negotiateRetry):
+		}
+	}
+}
+
+// Sentinel errors distinguishing the fatal negotiation outcome from the
+// retryable ones (see negotiate).
+var (
+	// errUnsupportedVersions: the Cluster resource is served, but at no
+	// version this build understands. Structural, not transient.
+	errUnsupportedVersions = errors.New("capi: no supported cluster.x-k8s.io version served")
+	// errClusterResourceAbsent: the Cluster resource is not served at all
+	// (ClusterAPI is not installed on the hub, or not installed yet).
+	errClusterResourceAbsent = errors.New("capi: cluster.x-k8s.io clusters resource not served")
+	// errNoDiscoveryClient: construction bug, not a cluster condition.
+	errNoDiscoveryClient = errors.New("capi: no discovery client")
+)
+
+// resolveClusterGVR asks the API server which versions of
+// clusters.cluster.x-k8s.io it serves and returns the most preferred
+// supported one. When the resource is served only at versions this build
+// does not support it fails loudly — naming the group/resource, the versions
+// this build supports, and the versions the server serves — rather than
+// letting an unserved version turn into an endlessly retried 404 and an
+// apparently empty fleet (issue #28).
+func resolveClusterGVR(d k8sdiscovery.DiscoveryInterface) (schema.GroupVersionResource, error) {
+	var zero schema.GroupVersionResource
+	if d == nil {
+		return zero, fmt.Errorf("%w to negotiate the %s version", errNoDiscoveryClient, clusterGroupResource)
+	}
+
+	groups, err := d.ServerGroups()
+	if err != nil {
+		return zero, fmt.Errorf("capi: listing server API groups: %w", err)
+	}
+
+	// Versions the group advertises, then narrowed to those actually
+	// listing the "clusters" resource: a group version may exist for other
+	// resources without serving this one.
+	var served []string
+	for _, g := range groups.Groups {
+		if g.Name != clusterGroupResource.Group {
+			continue
+		}
+		for _, v := range g.Versions {
+			ok, err := servesResource(d, v.GroupVersion, clusterGroupResource.Resource)
+			if err != nil {
+				return zero, err
+			}
+			if ok {
+				served = append(served, v.Version)
+			}
+		}
+	}
+
+	for _, want := range supportedClusterVersions {
+		if slices.Contains(served, want) {
+			return clusterGroupResource.WithVersion(want), nil
+		}
+	}
+	if len(served) == 0 {
+		// ClusterAPI is not installed on this hub (or not yet): retryable,
+		// and distinct from a version skew.
+		return zero, fmt.Errorf("%w: %s not found in the discovery API",
+			errClusterResourceAbsent, clusterGroupResource)
+	}
+	return zero, fmt.Errorf("%w: %s serves none of %v (served: %v)",
+		errUnsupportedVersions, clusterGroupResource, supportedClusterVersions, served)
+}
+
+// servesResource reports whether the given group version lists the named
+// resource. A NotFound on the group version means "not served", not a
+// failure — the group list and the per-version resource list are two
+// separate reads and can disagree during an upgrade.
+func servesResource(d k8sdiscovery.DiscoveryInterface, groupVersion, resource string) (bool, error) {
+	list, err := d.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("capi: listing resources for %s: %w", groupVersion, err)
+	}
+	for _, r := range list.APIResources {
+		if r.Name == resource {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // upsert handles informer add/update events.

--- a/internal/discovery/capi/provider_test.go
+++ b/internal/discovery/capi/provider_test.go
@@ -2,6 +2,8 @@ package capi
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,15 +11,24 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
 
 	"github.com/moeritze/k8s-r8r/internal/discovery"
 )
 
-// cluster builds an unstructured CAPI Cluster object.
+// cluster builds an unstructured CAPI Cluster object at the version the
+// provider negotiates in these tests (see testClusterGVR).
 func cluster(ns, name string, labels map[string]string, conditions []any) *unstructured.Unstructured {
+	return clusterAt("cluster.x-k8s.io/v1beta2", ns, name, labels, conditions)
+}
+
+// clusterAt builds an unstructured CAPI Cluster object at an explicit
+// apiVersion.
+func clusterAt(apiVersion, ns, name string, labels map[string]string, conditions []any) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{Object: map[string]any{
-		"apiVersion": "cluster.x-k8s.io/v1beta1",
+		"apiVersion": apiVersion,
 		"kind":       "Cluster",
 		"metadata": map[string]any{
 			"namespace": ns,
@@ -117,14 +128,65 @@ func TestRecordFromCluster(t *testing.T) {
 	}
 }
 
+// Negotiating the API version is only safe because record translation reads
+// nothing version-bound: ObjectMeta plus status.conditions[].type/.status,
+// which carry the same shape in the v1beta1 and v1beta2 condition sets.
+func TestRecordFromClusterIsVersionIndependent(t *testing.T) {
+	labels := map[string]string{"env": "prod"}
+	beta1 := recordFromCluster(clusterAt("cluster.x-k8s.io/v1beta1", "fleet", "prod-eu", labels,
+		[]any{condition("ControlPlaneReady", "True")}))
+	beta2 := recordFromCluster(clusterAt("cluster.x-k8s.io/v1beta2", "fleet", "prod-eu", labels,
+		[]any{condition("ControlPlaneAvailable", "True")}))
+
+	if !recordsEqual(beta1, beta2) {
+		t.Fatalf("record differs by API version:\n v1beta1 = %+v\n v1beta2 = %+v", beta1, beta2)
+	}
+	if !beta2.Ready {
+		t.Error("v1beta2 ControlPlaneAvailable=True did not yield Ready")
+	}
+}
+
+// fakeDiscovery builds a discovery client serving the given
+// cluster.x-k8s.io versions for the "clusters" resource. Versions listed in
+// otherResourceOnly are served by the group but do not carry the clusters
+// resource.
+func fakeDiscovery(versions []string, otherResourceOnly ...string) *discoveryfake.FakeDiscovery {
+	lists := make([]*metav1.APIResourceList, 0, len(versions)+len(otherResourceOnly))
+	for _, v := range versions {
+		lists = append(lists, &metav1.APIResourceList{
+			GroupVersion: "cluster.x-k8s.io/" + v,
+			APIResources: []metav1.APIResource{
+				{Name: "machines", Namespaced: true, Kind: "Machine"},
+				{Name: "clusters", Namespaced: true, Kind: "Cluster"},
+			},
+		})
+	}
+	for _, v := range otherResourceOnly {
+		lists = append(lists, &metav1.APIResourceList{
+			GroupVersion: "cluster.x-k8s.io/" + v,
+			APIResources: []metav1.APIResource{
+				{Name: "machines", Namespaced: true, Kind: "Machine"},
+			},
+		})
+	}
+	return &discoveryfake.FakeDiscovery{Fake: &clienttesting.Fake{Resources: lists}}
+}
+
+// testClusterGVR is the GVR the fake dynamic client is registered for in
+// these tests: the negotiated version for a hub serving v1beta1 + v1beta2.
+var testClusterGVR = clusterGroupResource.WithVersion("v1beta2")
+
 // startTestProvider runs a provider against a fake dynamic client and
-// returns the provider plus a channel of emitted events.
+// returns the provider plus a channel of emitted events. The fake hub serves
+// v1beta1 and v1beta2, so Start must negotiate v1beta2.
 func startTestProvider(t *testing.T, objs ...runtime.Object) (*Provider, chan discovery.Event, *dynamicfake.FakeDynamicClient) {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
-		map[schema.GroupVersionResource]string{clusterGVR: "ClusterList"}, objs...)
-	p := New(dyn, WithResync(0))
+		map[schema.GroupVersionResource]string{testClusterGVR: "ClusterList"}, objs...)
+	p := New(dyn,
+		WithDiscovery(fakeDiscovery([]string{"v1beta1", "v1beta2"})),
+		WithResync(0))
 	events := make(chan discovery.Event, 32)
 	p.Subscribe(func(e discovery.Event) { events <- e })
 
@@ -158,7 +220,7 @@ func TestProviderLifecycle(t *testing.T) {
 
 	// New cluster appears, not yet ready.
 	beta := cluster("fleet", "beta", nil, []any{condition("ControlPlaneReady", "False")})
-	if _, err := dyn.Resource(clusterGVR).Namespace("fleet").Create(context.Background(), beta, metav1.CreateOptions{}); err != nil {
+	if _, err := dyn.Resource(testClusterGVR).Namespace("fleet").Create(context.Background(), beta, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create beta: %v", err)
 	}
 	e = waitEvent(t, events)
@@ -168,7 +230,7 @@ func TestProviderLifecycle(t *testing.T) {
 
 	// beta becomes ready -> Update with Ready=true.
 	betaReady := cluster("fleet", "beta", nil, []any{condition("ControlPlaneReady", "True")})
-	if _, err := dyn.Resource(clusterGVR).Namespace("fleet").Update(context.Background(), betaReady, metav1.UpdateOptions{}); err != nil {
+	if _, err := dyn.Resource(testClusterGVR).Namespace("fleet").Update(context.Background(), betaReady, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update beta: %v", err)
 	}
 	e = waitEvent(t, events)
@@ -177,7 +239,7 @@ func TestProviderLifecycle(t *testing.T) {
 	}
 
 	// Deletion -> Deregister.
-	if err := dyn.Resource(clusterGVR).Namespace("fleet").Delete(context.Background(), "alpha", metav1.DeleteOptions{}); err != nil {
+	if err := dyn.Resource(testClusterGVR).Namespace("fleet").Delete(context.Background(), "alpha", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("delete alpha: %v", err)
 	}
 	e = waitEvent(t, events)
@@ -209,7 +271,7 @@ func TestProviderNoEventOnNoChange(t *testing.T) {
 
 	// Re-update with identical content: no event expected.
 	same := cluster("fleet", "alpha", nil, []any{condition("ControlPlaneReady", "True")})
-	if _, err := dyn.Resource(clusterGVR).Namespace("fleet").Update(context.Background(), same, metav1.UpdateOptions{}); err != nil {
+	if _, err := dyn.Resource(testClusterGVR).Namespace("fleet").Update(context.Background(), same, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("update: %v", err)
 	}
 	select {
@@ -232,5 +294,207 @@ func TestProviderRegisteredInDefaultRegistry(t *testing.T) {
 	// Factory validates missing hub config.
 	if _, err := discovery.New(ProviderName, discovery.Options{}); err == nil {
 		t.Fatal("New without HubConfig succeeded, want error")
+	}
+}
+
+// The preference list is what the provider is validated against; the
+// negotiation contract is only meaningful relative to it.
+func TestSupportedClusterVersionsOrder(t *testing.T) {
+	want := []string{"v1", "v1beta2", "v1beta1"}
+	if len(supportedClusterVersions) != len(want) {
+		t.Fatalf("supportedClusterVersions = %v, want %v", supportedClusterVersions, want)
+	}
+	for i, v := range want {
+		if supportedClusterVersions[i] != v {
+			t.Fatalf("supportedClusterVersions = %v, want %v (most preferred first)", supportedClusterVersions, want)
+		}
+	}
+}
+
+func TestResolveClusterGVR(t *testing.T) {
+	tests := []struct {
+		name string
+		// served versions carrying the "clusters" resource.
+		served []string
+		// versions the group serves without the "clusters" resource.
+		otherOnly []string
+		want      string
+		// wantErr is the sentinel the error must wrap (nil = success).
+		wantErr     error
+		errContains []string
+	}{
+		{
+			name:   "only the legacy version (CAPI <= 1.10 style)",
+			served: []string{"v1beta1"},
+			want:   "v1beta1",
+		},
+		{
+			name:   "deprecated and current served (CAPI 1.11 style)",
+			served: []string{"v1beta1", "v1beta2"},
+			want:   "v1beta2",
+		},
+		{
+			name:   "v1beta1 unserved (CAPI 1.16 style) still negotiates",
+			served: []string{"v1beta2"},
+			want:   "v1beta2",
+		},
+		{
+			name:   "GA wins over everything",
+			served: []string{"v1beta1", "v1beta2", "v1"},
+			want:   "v1",
+		},
+		{
+			name:   "unknown newer version ignored in favor of a supported one",
+			served: []string{"v1beta2", "v2beta1"},
+			want:   "v1beta2",
+		},
+		{
+			name:        "only unsupported versions served is fatal",
+			served:      []string{"v1alpha3", "v1alpha4"},
+			wantErr:     errUnsupportedVersions,
+			errContains: []string{"clusters.cluster.x-k8s.io", "v1beta1", "v1alpha3"},
+		},
+		{
+			name:        "group absent entirely is retryable, not fatal",
+			served:      nil,
+			wantErr:     errClusterResourceAbsent,
+			errContains: []string{"clusters.cluster.x-k8s.io"},
+		},
+		{
+			name:        "group present but resource missing from every version",
+			served:      nil,
+			otherOnly:   []string{"v1beta1", "v1beta2"},
+			wantErr:     errClusterResourceAbsent,
+			errContains: []string{"clusters.cluster.x-k8s.io"},
+		},
+		{
+			name:      "resource served on only one of the group's versions",
+			served:    []string{"v1beta1"},
+			otherOnly: []string{"v1beta2"},
+			want:      "v1beta1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gvr, err := resolveClusterGVR(fakeDiscovery(tc.served, tc.otherOnly...))
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("resolveClusterGVR = %v, want error", gvr)
+				}
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("error %q does not wrap %v", err, tc.wantErr)
+				}
+				for _, want := range tc.errContains {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q does not name %q", err, want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveClusterGVR: %v", err)
+			}
+			want := schema.GroupVersionResource{Group: "cluster.x-k8s.io", Version: tc.want, Resource: "clusters"}
+			if gvr != want {
+				t.Fatalf("resolveClusterGVR = %v, want %v", gvr, want)
+			}
+		})
+	}
+}
+
+func TestResolveClusterGVRNoDiscoveryClient(t *testing.T) {
+	if _, err := resolveClusterGVR(nil); err == nil {
+		t.Fatal("resolveClusterGVR(nil) succeeded, want error")
+	}
+}
+
+// The whole point of #28: an unserved version must stop the provider with a
+// named error instead of leaving it wedged in WaitForCacheSync while
+// reporting an empty fleet.
+func TestStartFailsLoudlyWhenNoSupportedVersionIsServed(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{testClusterGVR: "ClusterList"})
+	p := New(dyn,
+		WithDiscovery(fakeDiscovery([]string{"v1alpha4"})),
+		WithResync(0))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- p.Start(ctx) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Start succeeded, want error naming the unserved versions")
+		}
+		for _, want := range []string{"clusters.cluster.x-k8s.io", "v1beta1", "v1alpha4"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Start error %q does not name %q", err, want)
+			}
+		}
+	case <-ctx.Done():
+		t.Fatal("Start blocked instead of returning an error (issue #28: the silent wedge)")
+	}
+
+	if p.Watching() {
+		t.Error("Watching() = true after a failed start")
+	}
+	if len(p.List()) != 0 {
+		t.Error("List() non-empty after a failed start")
+	}
+}
+
+// A hub without ClusterAPI at all is a different case from a version skew:
+// the CRD may be installed later (the documented kind quickstart runs
+// exactly this way), so the provider waits instead of taking the manager
+// down — while reporting itself as not watching so the outage is still
+// visible in k8s_r8r_discovery_up.
+func TestStartWaitsWhenClusterResourceIsAbsent(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{testClusterGVR: "ClusterList"})
+	p := New(dyn, WithDiscovery(fakeDiscovery(nil)), WithResync(0))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- p.Start(ctx) }()
+
+	// Still waiting, not failed.
+	select {
+	case err := <-done:
+		cancel()
+		t.Fatalf("Start returned %v, want it to keep retrying", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	if p.Watching() {
+		t.Error("Watching() = true while the Cluster resource is absent")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start after cancel = %v, want nil (shutdown is not a failure)", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+}
+
+// Watching() is the signal that separates "discovery is broken" from "the
+// fleet is empty" — both of which show zero clusters.
+func TestWatchingReportsProviderHealth(t *testing.T) {
+	p, _, _ := startTestProvider(t) // no Cluster objects: a genuinely empty fleet
+	deadline := time.Now().Add(5 * time.Second)
+	for !p.Watching() {
+		if time.Now().After(deadline) {
+			t.Fatal("Watching() never became true with a healthy informer")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(p.List()) != 0 {
+		t.Fatalf("List = %v, want empty", p.List())
 	}
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -102,4 +102,11 @@ type Provider interface {
 	Start(ctx context.Context) error
 	// List returns a snapshot of all currently known cluster records.
 	List() []ClusterRecord
+	// Watching reports whether the provider's inventory source is
+	// established (for watch-based providers: the informer is running and
+	// synced). It exists because List alone cannot distinguish a broken
+	// provider from a fleet with no clusters — both return nothing — and
+	// that ambiguity is exactly what makes a discovery outage invisible.
+	// It is the source of the k8s_r8r_discovery_up metric.
+	Watching() bool
 }

--- a/internal/discovery/registry_test.go
+++ b/internal/discovery/registry_test.go
@@ -18,6 +18,7 @@ func (s *stubProvider) Start(ctx context.Context) error {
 	return nil
 }
 func (s *stubProvider) List() []ClusterRecord { return s.records }
+func (s *stubProvider) Watching() bool        { return true }
 
 func TestRegistry(t *testing.T) {
 	r := NewRegistry()

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -20,8 +20,8 @@ limitations under the License.
 // # Cardinality rule
 //
 // Metric labels are BOUNDED: only cluster, namespace, kind, and small
-// enumerations (dimension, policy, action, result) may appear as label
-// values — never object names or any other unbounded identifier. Object
+// enumerations (dimension, policy, action, result, provider) may appear as
+// label values — never object names or any other unbounded identifier. Object
 // names belong in events, not metrics. A unit test walks every registered
 // k8s_r8r_* metric and enforces this.
 //
@@ -51,6 +51,10 @@ const (
 	labelPolicy    = "policy"
 	labelAction    = "action"
 	labelResult    = "result"
+	// labelProvider is the discovery provider's registry name
+	// ("cluster-api", ...) — a closed set with exactly one value per
+	// process.
+	labelProvider = "provider"
 )
 
 var (
@@ -290,6 +294,77 @@ func (c *clusterCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
+// DiscoveryState is the discovery provider's own health snapshot: whether
+// its inventory watch is established, and how many clusters it currently
+// knows about.
+//
+// This is deliberately separate from k8s_r8r_clusters, which counts
+// *runtimes* registered with the cluster manager — three layers downstream
+// of discovery, and therefore 0 both when discovery is structurally broken
+// and when the fleet is genuinely empty. Up distinguishes the two.
+type DiscoveryState struct {
+	// Provider is the discovery provider's registry name (bounded label).
+	Provider string
+	// Up reports whether the provider's inventory watch is established.
+	Up bool
+	// Clusters is the size of the provider's own inventory (List()).
+	Clusters int
+}
+
+// discoveryCollector renders the discovery provider's health snapshot as
+// gauges at scrape time. The source is injected (SetDiscoverySnapshot) to
+// keep this package free of internal dependencies, exactly like
+// SetClusterSnapshot.
+type discoveryCollector struct {
+	upDesc       *prometheus.Desc
+	clustersDesc *prometheus.Desc
+}
+
+var discoverySource struct {
+	mu sync.Mutex
+	fn func() DiscoveryState
+}
+
+// SetDiscoverySnapshot wires the discovery-health source: a function
+// returning the configured provider's name, watch state, and inventory size.
+func SetDiscoverySnapshot(fn func() DiscoveryState) {
+	discoverySource.mu.Lock()
+	defer discoverySource.mu.Unlock()
+	discoverySource.fn = fn
+}
+
+func newDiscoveryCollector() *discoveryCollector {
+	return &discoveryCollector{
+		upDesc: prometheus.NewDesc("k8s_r8r_discovery_up",
+			"1 when the configured discovery provider's inventory watch is established, 0 otherwise. Distinguishes broken discovery from an empty fleet.", []string{labelProvider}, nil),
+		clustersDesc: prometheus.NewDesc("k8s_r8r_discovery_clusters",
+			"Number of clusters in the discovery provider's own inventory (distinct from k8s_r8r_clusters, which counts registered runtimes).", []string{labelProvider}, nil),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *discoveryCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.upDesc
+	ch <- c.clustersDesc
+}
+
+// Collect implements prometheus.Collector.
+func (c *discoveryCollector) Collect(ch chan<- prometheus.Metric) {
+	discoverySource.mu.Lock()
+	fn := discoverySource.fn
+	discoverySource.mu.Unlock()
+	if fn == nil {
+		return
+	}
+	s := fn()
+	up := 0.0
+	if s.Up {
+		up = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.upDesc, prometheus.GaugeValue, up, s.Provider)
+	ch <- prometheus.MustNewConstMetric(c.clustersDesc, prometheus.GaugeValue, float64(s.Clusters), s.Provider)
+}
+
 func init() {
 	metrics.Registry.MustRegister(
 		policyDenials,
@@ -301,5 +376,6 @@ func init() {
 		tokenRotations,
 		replicas,
 		newClusterCollector(),
+		newDiscoveryCollector(),
 	)
 }

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -44,6 +44,9 @@ func exerciseAll() {
 	SetClusterSnapshot(func() map[string]float64 {
 		return map[string]float64{"spoke-a": ConnectivityReachable}
 	})
+	SetDiscoverySnapshot(func() DiscoveryState {
+		return DiscoveryState{Provider: "cluster-api", Up: true, Clusters: 1}
+	})
 }
 
 func gatherOurs(t *testing.T) map[string]*dto.MetricFamily {
@@ -76,6 +79,8 @@ func TestMetricLabelCardinalityBounded(t *testing.T) {
 		"policy":    true,
 		"action":    true,
 		"result":    true,
+		// The discovery provider's registry name: one value per process.
+		"provider": true,
 	}
 	fams := gatherOurs(t)
 	if len(fams) == 0 {
@@ -109,6 +114,8 @@ func TestMetricInventoryComplete(t *testing.T) {
 		"k8s_r8r_drift_events_total",
 		"k8s_r8r_cluster_connectivity",
 		"k8s_r8r_clusters",
+		"k8s_r8r_discovery_up",
+		"k8s_r8r_discovery_clusters",
 		"k8s_r8r_spoke_bootstraps_total",
 		"k8s_r8r_token_rotations_total",
 	} {
@@ -154,6 +161,51 @@ func replicaValue(t *testing.T, family string) float64 {
 			}
 		}
 	}
+	return 0
+}
+
+// A broken discovery provider and a genuinely empty fleet must not produce
+// the same observation: both show zero clusters, only the up gauge separates
+// them (observability-operations: discovery health).
+func TestDiscoveryHealthDistinguishesBrokenFromEmpty(t *testing.T) {
+	t.Cleanup(func() {
+		SetDiscoverySnapshot(func() DiscoveryState {
+			return DiscoveryState{Provider: "cluster-api", Up: true, Clusters: 1}
+		})
+	})
+
+	SetDiscoverySnapshot(func() DiscoveryState {
+		return DiscoveryState{Provider: "cluster-api", Up: true, Clusters: 0}
+	})
+	if got := discoveryValue(t, "k8s_r8r_discovery_up"); got != 1 {
+		t.Errorf("empty fleet: up = %v, want 1", got)
+	}
+	if got := discoveryValue(t, "k8s_r8r_discovery_clusters"); got != 0 {
+		t.Errorf("empty fleet: clusters = %v, want 0", got)
+	}
+
+	SetDiscoverySnapshot(func() DiscoveryState {
+		return DiscoveryState{Provider: "cluster-api", Up: false, Clusters: 0}
+	})
+	if got := discoveryValue(t, "k8s_r8r_discovery_up"); got != 0 {
+		t.Errorf("broken provider: up = %v, want 0", got)
+	}
+}
+
+func discoveryValue(t *testing.T, family string) float64 {
+	t.Helper()
+	mf, ok := gatherOurs(t)[family]
+	if !ok {
+		t.Fatalf("family %s not found", family)
+	}
+	for _, m := range mf.GetMetric() {
+		for _, lp := range m.GetLabel() {
+			if lp.GetName() == "provider" && lp.GetValue() == "cluster-api" {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	t.Fatalf("family %s has no cluster-api sample", family)
 	return 0
 }
 

--- a/obsidian/cluster-discovery.md
+++ b/obsidian/cluster-discovery.md
@@ -8,10 +8,26 @@ Pluggable provider interface turns fleet-management systems into replication tar
 
 ## ClusterAPI provider (v1)
 
-`internal/discovery/capi` watches `cluster.x-k8s.io/v1beta1 Cluster` objects **unstructured** (no CAPI module dependency — keeps go.mod lean, decouples from CAPI's k8s version pins):
+`internal/discovery/capi` watches `cluster.x-k8s.io Cluster` objects **unstructured** (no CAPI module dependency — keeps go.mod lean, decouples from CAPI's k8s version pins):
 - selection labels = the `Cluster` object's labels (used by [[replication-flow|`r8r.io/target-clusters`]] and [[policy-model|policy `clusterSelector`]])
 - targetable only when control plane ready (`ControlPlaneReady` v1beta1 / `ControlPlaneAvailable` v1beta2)
 - credentials from the conventional `<cluster>-kubeconfig` Secret
+
+## API version negotiation
+
+The watched version is **not pinned**. On start the provider asks the hub's discovery API which versions of `clusters.cluster.x-k8s.io` are served and takes the first of `v1 → v1beta2 → v1beta1` that appears, logging the choice once:
+
+```
+Negotiated ClusterAPI discovery version  groupVersion=cluster.x-k8s.io/v1beta2 resource=clusters
+```
+
+The list is explicit rather than the group's `preferredVersion`, so the provider never binds to a CAPI version whose readiness-condition vocabulary it has not been validated against. Nothing else in the provider is version-bound: records read `ObjectMeta` plus `status.conditions[].type/.status`, identical in both condition sets.
+
+Failure modes, deliberately different:
+- **served, but at no supported version** (CAPI 1.16 drops `v1beta1` and this build is older) → the provider **fails to start** with `capi: clusters.cluster.x-k8s.io serves none of [v1 v1beta2 v1beta1] (served: [...])`. The manager stops and the pod restarts with the reason in its logs. Readiness is untouched — that gate is still hub-informers-only.
+- **not served at all / hub unreachable** → retries every 30s, logs why, and reports `k8s_r8r_discovery_up=0` (see [[operations]]). ClusterAPI installed after the operator converges on its own.
+
+Before this, the GVR was pinned to `v1beta1`: an unserved version returned 404, the reflector retried forever, `Start` hung in `WaitForCacheSync`, the pod stayed Ready, and the fleet looked empty. Issue #28.
 
 ## Credential bootstrap (D5)
 

--- a/obsidian/operations.md
+++ b/obsidian/operations.md
@@ -6,7 +6,29 @@ tags: [functionality, operations]
 
 ## Metrics (`internal/telemetry`, prefix `k8s_r8r_`)
 
-Replica desired/ready/failed gauges (per cluster) · policy/webhook denial counters (per dimension) · conflict, revocation, drift counters · cluster connectivity gauge (0 unreachable / 1 degraded / 2 reachable) · bootstrap + token rotation counters. Reconcile durations/workqueue depth come from controller-runtime built-ins. Cardinality bounded by test: labels only cluster/namespace/kind — never object names.
+Replica desired/ready/failed gauges (per cluster) · policy/webhook denial counters (per dimension) · conflict, revocation, drift counters · cluster connectivity gauge (0 unreachable / 1 degraded / 2 reachable) · bootstrap + token rotation counters. Reconcile durations/workqueue depth come from controller-runtime built-ins. Cardinality bounded by test: labels only cluster/namespace/kind/provider — never object names.
+
+**Discovery health** (`k8s_r8r_discovery_up{provider}`, `k8s_r8r_discovery_clusters{provider}`) comes from the [[cluster-discovery|provider itself]], not from the runtime manager. `k8s_r8r_clusters` counts registered *runtimes* and reads 0 both when discovery is broken and when the fleet is genuinely empty — that ambiguity is what kept a total discovery outage invisible (#28). Read them together:
+
+| `discovery_up` | `discovery_clusters` | meaning |
+|---|---|---|
+| 1 | 0 | discovery works, no clusters match |
+| 1 | n | healthy |
+| 0 | 0 | discovery is not running — alert on this |
+
+## Troubleshooting
+
+**Zero clusters discovered.** First check `k8s_r8r_discovery_up`. If it is 1, the fleet really has no `Cluster` objects (or none the provider's namespace setting sees) — this is not an operator fault. If it is 0, check the negotiated CAPI version in the operator log:
+
+```sh
+kubectl -n k8s-r8r-system logs deploy/k8s-r8r | grep -i 'ClusterAPI'
+```
+
+- `Negotiated ClusterAPI discovery version groupVersion=... ` — discovery started fine; look further downstream.
+- `capi: clusters.cluster.x-k8s.io serves none of [v1 v1beta2 v1beta1] (served: [...])` — the hub's CAPI is newer (or older) than this build supports; the pod restarts on this. Upgrade k8s-r8r to a build that lists a served version.
+- `ClusterAPI inventory unavailable, retrying` — no `clusters.cluster.x-k8s.io` on the hub at all (ClusterAPI not installed) or the hub is unreachable. The operator waits and converges once it appears.
+
+Note the pod stays **Ready** through all of these: readiness reflects hub informer sync only, by design. Discovery health lives in the metric, not in the probe.
 
 ## Events
 

--- a/openspec/changes/negotiate-capi-cluster-version/.openspec.yaml
+++ b/openspec/changes/negotiate-capi-cluster-version/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/negotiate-capi-cluster-version/README.md
+++ b/openspec/changes/negotiate-capi-cluster-version/README.md
@@ -1,0 +1,3 @@
+# negotiate-capi-cluster-version
+
+Negotiate the served cluster.x-k8s.io version for CAPI discovery instead of pinning v1beta1, and fail loudly when none is served

--- a/openspec/changes/negotiate-capi-cluster-version/design.md
+++ b/openspec/changes/negotiate-capi-cluster-version/design.md
@@ -1,0 +1,150 @@
+# Design: CAPI Cluster version negotiation
+
+## Context
+
+`internal/discovery/capi` reads CAPI `Cluster` objects unstructured through a
+dynamic informer, deliberately avoiding a `sigs.k8s.io/cluster-api` import.
+That choice is what makes version negotiation cheap: there are no generated
+Go types bound to one API version, only a `GroupVersionResource` and two
+field paths (`metadata.labels`, `status.conditions[]`). The pinned version
+was the only versioned thing left.
+
+## Decisions
+
+### D1: Explicit preference list, not the group's preferred version
+
+`resolveClusterGVR` intersects the versions the API server serves for
+`clusters.cluster.x-k8s.io` with an ordered, in-code list:
+
+```go
+var supportedClusterVersions = []string{"v1", "v1beta2", "v1beta1"}
+```
+
+and returns the first list entry that is served. Rejected alternative: take
+the group's `preferredVersion` from `/apis`. That auto-adopts any future
+version the moment a management cluster starts serving it, including one
+whose readiness-condition vocabulary this provider has never been validated
+against — the provider would silently report every cluster as not-ready
+instead of not discovering them, trading one silent failure for another. The
+explicit list makes "which CAPI versions is this build validated for?" a
+readable constant and a reviewable diff.
+
+`v1` leads the list because CAPI's own deprecation notes point at a future
+GA; it costs one string and means the next bump is a one-line change with a
+test, not an incident.
+
+### D2: Resolve in `Start`, fail loudly, before the informer
+
+Resolution happens inside `Start`, not in the registry factory, and not in
+`init`. The factory runs during process startup, before the manager's
+lifecycle exists; a hub that is briefly unreachable there would crash-loop
+the operator for a transient condition. Inside `Start` the provider is a
+manager `Runnable` and failure is handled by the manager's normal shutdown.
+
+Two negotiation failures are separated, because they need opposite
+responses:
+
+| condition | response | why |
+|---|---|---|
+| resource served, no supported version | fatal — `Start` returns | structural skew between this build and the hub; it will not resolve itself |
+| resource absent, or hub unreachable | retry every 30s, `Watching() == false`, reason logged | ClusterAPI may be installed later; the documented kind quickstart runs a hub with none |
+
+Collapsing the second case into the first would crash-loop the operator on
+the fleet the quickstart tells people to build, and would make the e2e
+suite's install-then-apply-CRD order fail — while buying nothing, since the
+condition is visible in `k8s_r8r_discovery_up` either way. Neither case is
+silent, which is the actual bug.
+
+When the resource is served at no known version, `Start` returns before
+creating the informer:
+
+```
+capi: clusters.cluster.x-k8s.io serves none of [v1 v1beta2 v1beta1] (served: [v1alpha3 v1alpha4])
+```
+
+The error names the group/resource, the versions this build accepts, and the
+versions the server actually serves — everything needed to diagnose it from
+one log line.
+
+A non-nil return from a `Runnable` stops the manager, so the pod restarts
+and the message is in its logs. This does **not** conflict with the
+`observability-operations` requirement that "individual unreachable target
+clusters SHALL NOT make the operator unready": that requirement is about
+*spokes*, and the isolation it demands is provided by per-cluster runtimes
+and per-cluster connectivity state. Discovery serving no known version is
+not one spoke being down — it is the inventory source being structurally
+unusable, where every replication target is unreachable and staying up
+buys nothing. Readiness itself is untouched (still hub-informers-synced
+only); the pod does not go "not ready", it exits.
+
+### D3: Bounded cache sync
+
+`cache.WaitForCacheSync(ctx.Done(), ...)` waits forever on a reflector that
+retries a retryable error forever. It is now bounded by a derived context
+(`cacheSyncTimeout`, 2m — the same order as controller-runtime's own cache
+sync timeout), so a never-syncing informer produces
+`capi: cluster informer cache never synced within 2m0s` instead of a silent
+hang. Negotiation removes the known cause of that hang; the timeout covers
+the unknown ones (RBAC on `clusters`, a wedged aggregated API).
+
+### D4: Discovery-health metrics, separate from the runtime count
+
+`k8s_r8r_clusters` is derived from the cluster *runtime manager*, three
+layers downstream of discovery, and reads 0 for both "discovery is broken"
+and "no clusters match". Two new gauges break the ambiguity at the source:
+
+| metric | source | 0 means |
+|---|---|---|
+| `k8s_r8r_discovery_up{provider}` | provider watch established | discovery is not running |
+| `k8s_r8r_discovery_clusters{provider}` | provider `List()` | discovery works, the fleet is empty |
+
+`up=1, clusters=0` is a genuinely empty fleet. `up=0` is a broken provider —
+and with the fail-loud path above, a pod that is restarting with a named
+error rather than sitting green. The alert worth writing is
+`k8s_r8r_discovery_up == 0`.
+
+`provider` is a bounded label: its value space is the discovery registry's
+provider names (one value in any given process). It is added to the
+cardinality allowlist in `internal/telemetry/metrics_test.go` alongside the
+other closed enumerations.
+
+Wiring follows the existing `SetClusterSnapshot` pattern: `cmd/main.go`
+injects a snapshot function so `internal/telemetry` keeps no dependency on
+`internal/discovery`. The gauges are collected at scrape time.
+
+### D5: Ready conditions are already version-tolerant (verified, not assumed)
+
+`readyConditionTypes` accepts `ControlPlaneReady` (v1beta1) or
+`ControlPlaneAvailable` (the v1beta2 condition set), and `controlPlaneReady`
+walks `status.conditions[]` reading only `type` and `status` as strings via
+`unstructured.NestedSlice`. Both the v1beta1 (`clusterv1.Condition`) and
+v1beta2 (`metav1.Condition`) condition shapes carry `type` and `status` as
+strings at that path, so nothing in the readiness path is version-bound.
+`recordFromCluster` reads only `metadata.name`, `metadata.namespace` and
+`metadata.labels`, which are `ObjectMeta` and therefore version-invariant.
+Negotiating the version does not require touching the record translation.
+
+### D6: e2e serves two versions
+
+`test/e2e/testdata/capi-cluster-crd.yaml` served only `v1beta1`, so a
+negotiating provider would pick `v1beta1` and the new code path would never
+be exercised. The CRD now declares `v1beta2` (served, storage) and
+`v1beta1` (served, not storage) — the shape of a CAPI 1.11+ management
+cluster. The provider must then negotiate `v1beta2`, and the suite's own
+`clusterGVK` moves to `v1beta2` to match the storage version. Both versions
+use `x-kubernetes-preserve-unknown-fields` with the default `None`
+conversion strategy, so no conversion webhook is needed.
+
+## Risks
+
+- **A CAPI release adds a version we do not list.** The provider keeps using
+  the newest *listed* served version; nothing breaks, and the negotiated
+  version is in the logs. Adding the new version is a one-line change once
+  its condition vocabulary is checked.
+- **A partially-broken discovery API.** `resolveClusterGVR` queries
+  `/apis` and then only the candidate group-versions, so an unrelated
+  aggregated APIService being down cannot fail CAPI discovery.
+- **Restart loop on a truly misconfigured hub.** Intended: an operator that
+  cannot see its inventory source is not doing useful work, and
+  `CrashLoopBackOff` with a named error is a signal, whereas green-and-idle
+  is not.

--- a/openspec/changes/negotiate-capi-cluster-version/proposal.md
+++ b/openspec/changes/negotiate-capi-cluster-version/proposal.md
@@ -1,0 +1,97 @@
+# Negotiate the served CAPI Cluster version
+
+## Why
+
+The ClusterAPI discovery provider hardcodes `cluster.x-k8s.io/v1beta1`
+(`internal/discovery/capi/provider.go`, package-level `clusterGVR`). CAPI has
+moved its storage version to `v1beta2` and has scheduled `v1beta1` to stop
+being served in CAPI 1.16. When that happens the failure is total and silent:
+
+- the dynamic informer's list/watch against the unserved version gets `404`,
+  which the reflector treats as retryable and retries forever, so
+  `HasSynced` never flips and `Start` blocks inside `cache.WaitForCacheSync`
+  until context cancellation — the `cluster informer cache never synced`
+  error only surfaces at *shutdown*;
+- readiness is hub-cache-only by design, so the pod stays `Ready`;
+- `k8s_r8r_clusters` reads `0` from the cluster **runtime manager** snapshot,
+  which is indistinguishable from a genuinely empty fleet;
+- annotated Secrets still materialize `Replication`s, with zero targets and
+  no denial event.
+
+Green pod, green probes, zero replication, no operator-visible signal, on a
+scheduled upstream trigger.
+
+Two spec observations, both of which explain how this slipped through:
+
+1. **`cluster-discovery` is silent on versioning.** The "ClusterAPI provider"
+   requirement says the provider discovers targets from ClusterAPI `Cluster`
+   objects but says nothing about which API version. Today's pinned-GVR code
+   is therefore *not strictly non-conformant* — this change tightens the
+   requirement rather than fixing a violation of it.
+2. **`observability-operations`' metrics minimum is satisfied by the very
+   metric that cannot see the failure.** It requires "cluster runtime count",
+   and `k8s_r8r_clusters` delivers exactly that — a count derived from the
+   runtime manager, downstream of discovery. Structurally broken discovery
+   and an empty fleet produce the identical observation, so the required
+   metric inventory was complete while the failure stayed invisible. The
+   minimum is amended to include a discovery-health signal.
+
+## What Changes
+
+- **Version negotiation (behavior change).** The provider resolves the
+  `clusters.cluster.x-k8s.io` version from the hub's discovery API at
+  `Start`, intersecting the versions the API server actually serves with an
+  explicit, ordered preference list `[v1, v1beta2, v1beta1]`, and uses the
+  first hit. An explicit list is preferred over the group's
+  `preferredVersion` so the ready-condition contract stays auditable: the
+  provider never binds to a CAPI version it has not been validated against.
+- **Loud failure on version skew.** When the resource is served but at none
+  of the known versions, `Start` returns a named error before touching the
+  informer — e.g. `capi: clusters.cluster.x-k8s.io serves none of
+  [v1 v1beta2 v1beta1] (served: [v1alpha3 v1alpha4])`. As a manager
+  `Runnable`, a non-nil return stops the manager and restarts the pod with
+  the message in its logs, which is the correct response to a total,
+  non-transient misconfiguration.
+- **Retry, not failure, when ClusterAPI is simply absent.** A hub that is
+  unreachable, or that has no `clusters.cluster.x-k8s.io` at all, is a
+  different condition: both resolve themselves (an API server recovers,
+  ClusterAPI gets installed), and the documented kind quickstart deliberately
+  runs a hub with no ClusterAPI. The provider keeps retrying, logs why, and
+  reports itself as not watching — so the state is visible in
+  `k8s_r8r_discovery_up` instead of taking the operator down.
+- **Resolution at `Start`, not construction.** A hub that is unreachable at
+  process start must retry through the manager's normal lifecycle rather
+  than crash-loop the factory.
+- **Negotiated version logged once** at info level on success, so future
+  skew is visible before it becomes an outage.
+- **Bounded cache sync.** `cache.WaitForCacheSync` gets a timeout so a
+  never-syncing informer reports instead of hanging forever.
+- **Discovery-health metrics.** New `k8s_r8r_discovery_up{provider}` (1 when
+  the provider's watch is established, 0 otherwise) and
+  `k8s_r8r_discovery_clusters{provider}` (inventory size from the provider's
+  own `List()`, distinct from the runtime-manager-derived
+  `k8s_r8r_clusters`). `provider` is a bounded label — the registry's
+  provider names.
+- **e2e exercises negotiation.** `test/e2e/testdata/capi-cluster-crd.yaml`
+  serves only `v1beta1` today, so negotiation would be a no-op there. It now
+  serves `v1beta1` (deprecated) and `v1beta2` (served + storage), matching
+  the shape of a real CAPI 1.11+ management cluster.
+
+Not in scope: making the version selectable by configuration. A flag does
+not fix the silent half at all — set it wrong and you get the same wedged
+informer and the same green dashboard — and it moves a fact the API server
+already publishes into human-maintained config.
+
+## Impact
+
+- Specs: `cluster-discovery` (ClusterAPI provider requirement + new
+  scenario), `observability-operations` (metrics minimum).
+- Code: `internal/discovery/capi/provider.go`,
+  `internal/telemetry/metrics.go`, `cmd/main.go` (discovery wiring only).
+- Tests: `internal/discovery/capi/provider_test.go`,
+  `internal/telemetry/metrics_test.go`, `test/e2e/`.
+- Docs: `obsidian/cluster-discovery.md`, `obsidian/operations.md`,
+  `docs/quickstart.md`.
+- Fixes #28. Related: #37 (`discovery.Options.Settings` is never populated in
+  production) is deliberately left open — negotiation removes the need for a
+  manual escape hatch here.

--- a/openspec/changes/negotiate-capi-cluster-version/specs/cluster-discovery/spec.md
+++ b/openspec/changes/negotiate-capi-cluster-version/specs/cluster-discovery/spec.md
@@ -1,0 +1,30 @@
+# cluster-discovery
+
+## MODIFIED Requirements
+
+### Requirement: ClusterAPI provider
+The ClusterAPI provider SHALL discover targets from ClusterAPI `Cluster` objects on the hub. Cluster labels for selection are the `Cluster` object's labels. A cluster becomes a valid target only when its control plane is ready. `Cluster` deletion SHALL emit deregistration.
+
+The provider SHALL NOT pin a single `cluster.x-k8s.io` API version. On start it SHALL resolve the version to watch from the hub's discovery API, selecting the first version of a documented, ordered set of supported versions that the API server actually serves for `clusters.cluster.x-k8s.io`, and SHALL log the negotiated version once. Readiness evaluation SHALL remain version-tolerant across that set.
+
+When the resource is served but at none of the supported versions, the provider SHALL fail to start with an error naming the group/resource, the supported versions, and the versions the server serves, rather than starting and reporting an empty inventory. When the resource is not served at all, or the hub is unreachable — conditions that resolve themselves when the fleet-management system is installed or recovers — the provider SHALL retry rather than fail, and SHALL report itself as not watching for as long as it waits. The provider SHALL NOT block indefinitely waiting for its watch to establish.
+
+#### Scenario: New CAPI cluster becomes targetable
+- **WHEN** a ClusterAPI `Cluster` reaches control-plane-ready
+- **THEN** the provider emits its registration, the engine starts its cluster runtime, and pending requests selecting it begin replicating
+
+#### Scenario: CAPI cluster deleted
+- **WHEN** a `Cluster` object is deleted
+- **THEN** the provider emits deregistration, the cluster runtime stops, and inventory entries for that cluster are released per the engine's garbage-collection rules
+
+#### Scenario: Hub serves a newer CAPI version
+- **WHEN** the hub serves several supported `cluster.x-k8s.io` versions for `clusters` (for example a deprecated and a current one)
+- **THEN** the provider watches the most preferred supported version the hub serves, logs which version it negotiated, and discovers the same clusters regardless of which version is the storage version
+
+#### Scenario: CAPI Cluster CRD serves no supported version
+- **WHEN** `clusters.cluster.x-k8s.io` serves none of the provider's supported versions
+- **THEN** the provider fails to start with an error naming the group/resource and the versions the server serves, rather than reporting an empty inventory
+
+#### Scenario: ClusterAPI is not installed on the hub yet
+- **WHEN** `clusters.cluster.x-k8s.io` is absent from the hub's discovery API
+- **THEN** the provider logs the reason, reports itself as not watching, and retries until the resource appears, rather than failing the operator — and discovers clusters normally once ClusterAPI is installed

--- a/openspec/changes/negotiate-capi-cluster-version/specs/observability-operations/spec.md
+++ b/openspec/changes/negotiate-capi-cluster-version/specs/observability-operations/spec.md
@@ -1,0 +1,16 @@
+# observability-operations
+
+## MODIFIED Requirements
+
+### Requirement: Prometheus metrics
+The operator SHALL expose Prometheus metrics covering at minimum: replicas desired/ready/failed (by target cluster), reconcile durations and error counts (by controller), policy denials, conflicts, cluster connectivity state, cluster runtime count, discovery health, and workqueue depth. Metric labels SHALL be bounded (cluster, namespace, kind, provider, and small closed enumerations — never object names of unbounded cardinality).
+
+Discovery health SHALL be observable independently of the cluster runtime count: the operator SHALL expose whether the configured discovery provider's inventory watch is established, and the size of that provider's own inventory, so that a broken discovery provider is distinguishable from a fleet with no matching clusters.
+
+#### Scenario: Failing cluster visible in metrics
+- **WHEN** replication to a target cluster fails
+- **THEN** the failed-replica and connectivity metrics for that cluster reflect it within one scrape interval
+
+#### Scenario: Broken discovery is distinguishable from an empty fleet
+- **WHEN** the discovery provider's inventory watch is not established
+- **THEN** the discovery-health metric reads not-up, distinct from a running provider whose inventory is legitimately empty

--- a/openspec/changes/negotiate-capi-cluster-version/tasks.md
+++ b/openspec/changes/negotiate-capi-cluster-version/tasks.md
@@ -1,0 +1,36 @@
+## 1. Version negotiation in the CAPI provider
+
+- [x] 1.1 Replace the pinned `clusterGVR` package var with `clusterGroupResource` plus an ordered `supportedClusterVersions = []string{"v1", "v1beta2", "v1beta1"}`
+- [x] 1.2 Add `resolveClusterGVR(d discovery.DiscoveryInterface) (schema.GroupVersionResource, error)`: read served group-versions for `cluster.x-k8s.io`, keep those actually listing the `clusters` resource, return the first supported version in preference order
+- [x] 1.3 Return a named error when the resource is served at no supported version: `capi: clusters.cluster.x-k8s.io serves none of [...] (served: [...])`; keep "resource absent" / "hub unreachable" retryable (sentinel errors) so a hub without ClusterAPI waits instead of crash-looping
+- [x] 1.4 Build a discovery client next to the dynamic client in the registry factory; store it on `Provider` (`WithDiscovery` option for tests)
+- [x] 1.5 Resolve inside `Start`, before the informer is created, so an unreachable hub retries through the manager instead of crash-looping the factory
+- [x] 1.6 Log the negotiated version once at info level
+- [x] 1.7 Bound `cache.WaitForCacheSync` with a timeout and report it in the error
+
+## 2. Discovery-health metrics
+
+- [x] 2.1 Add `k8s_r8r_discovery_up{provider}` and `k8s_r8r_discovery_clusters{provider}` collectors to `internal/telemetry/metrics.go`, injected via `SetDiscoverySnapshot` (same pattern as `SetClusterSnapshot`)
+- [x] 2.2 Provider tracks its own watch state; `cmd/main.go` wires the snapshot from `provider.Name()` / `provider.List()` in the discovery region
+- [x] 2.3 Add `provider` to the cardinality allowlist and the new families to the metric inventory test
+
+## 3. Tests
+
+- [x] 3.1 Unit-test `resolveClusterGVR` against a fake discovery client: v1beta1 only, v1beta1+v1beta2, all three, only unsupported alpha versions, group absent entirely, resource absent from a served group-version
+- [x] 3.2 Unit-test that `Start` returns the named error (and never blocks) when no supported version is served, and that it waits (not fails) when the resource is absent
+- [x] 3.3 Verify readiness stays version-tolerant: `controlPlaneReady` covers `ControlPlaneReady` and `ControlPlaneAvailable` on a v1beta2 object
+- [x] 3.4 e2e: `test/e2e/testdata/capi-cluster-crd.yaml` serves `v1beta1` (deprecated) + `v1beta2` (served, storage); `test/e2e/framework.go` `clusterGVK` moves to `v1beta2`
+
+## 4. Docs
+
+- [x] 4.1 `internal/discovery/capi` package doc: replace the "cluster.x-k8s.io/v1beta1" statement of fact with the negotiated set
+- [x] 4.2 `obsidian/cluster-discovery.md`: negotiation + fail-loud behavior
+- [x] 4.3 `obsidian/operations.md`: discovery-health metrics and a "zero clusters discovered — check the negotiated CAPI version" troubleshooting entry
+- [x] 4.4 `docs/quickstart.md`: same troubleshooting entry next to the discovery section
+
+## 5. Verification
+
+- [x] 5.1 `openspec validate negotiate-capi-cluster-version --strict`
+- [x] 5.2 `make lint && make test`
+- [x] 5.3 Add `TestCAPIVersionNegotiation` asserting the operator logged the negotiated `v1beta2`; `go vet -tags e2e ./test/e2e/...` compiles
+- [ ] 5.4 **Not run:** `make test-e2e` — the Docker daemon was unavailable in this environment. The e2e suite compiles and the negotiation assertion is in place; it needs a run on a machine with docker before merge.

--- a/test/e2e/cluster_lifecycle_test.go
+++ b/test/e2e/cluster_lifecycle_test.go
@@ -62,6 +62,26 @@ func operatorPodReady(g Gomega) {
 	g.Expect(readyPods).To(BeNumerically(">=", 1), "operator pod must stay Ready")
 }
 
+// TestCAPIVersionNegotiation asserts the operator negotiated the CAPI
+// Cluster API version instead of pinning one (issue #28). The stand-in CRD
+// serves the deprecated v1beta1 alongside v1beta2, so a provider that still
+// pinned v1beta1 would pass every other test in this suite while being
+// exactly one CAPI release away from a silent, total outage. The negotiated
+// version is only observable in the operator's log, which is the point: it
+// is what makes future version skew visible before it becomes an incident.
+func TestCAPIVersionNegotiation(t *testing.T) {
+	g := NewWithT(t)
+	g.Eventually(func(g Gomega) {
+		out, err := kubectl(hubCluster, "-n", operatorNamespace, "logs",
+			"-l", "control-plane=controller-manager", "--tail=-1")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(out).To(ContainSubstring("Negotiated ClusterAPI discovery version"),
+			"operator never logged a negotiated CAPI version")
+		g.Expect(out).To(ContainSubstring("cluster.x-k8s.io/v1beta2"),
+			"operator did not negotiate v1beta2 from a CRD serving v1beta1 and v1beta2")
+	}, 2*time.Minute, 5*time.Second).Should(Succeed())
+}
+
 // TestClusterLifecycle drives spoke-2 through outage, deregistration, and
 // fresh re-registration while a replication to both spokes is live. It ends
 // with a fully healthy fleet.

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -25,7 +25,9 @@ limitations under the License.
 //
 // The suite never installs ClusterAPI. The discovery provider reads Cluster
 // objects unstructured, so testdata/capi-cluster-crd.yaml provides a minimal
-// clusters.cluster.x-k8s.io CRD; per spoke the suite creates a Cluster object
+// clusters.cluster.x-k8s.io CRD serving both v1beta2 (storage) and the
+// deprecated v1beta1, so the provider's version negotiation is exercised
+// rather than short-circuited; per spoke the suite creates a Cluster object
 // labeled env=e2e, patches ControlPlaneReady=True through the status
 // subresource, and writes the conventional "<name>-kubeconfig" Secret with an
 // INTERNAL kind kubeconfig (kind get kubeconfig --internal) under the "value"
@@ -88,8 +90,11 @@ const (
 // where the bootstrap creates the spoke artifacts.
 const operatorNamespace = "k8s-r8r-system"
 
-// clusterGVK identifies simulated ClusterAPI Cluster objects.
-var clusterGVK = schema.GroupVersionKind{Group: "cluster.x-k8s.io", Version: "v1beta1", Kind: "Cluster"}
+// clusterGVK identifies simulated ClusterAPI Cluster objects. The stand-in
+// CRD serves v1beta2 (storage) and the deprecated v1beta1, so the operator's
+// discovery provider has a real negotiation to perform (issue #28) and must
+// land on v1beta2; the suite writes at the storage version.
+var clusterGVK = schema.GroupVersionKind{Group: "cluster.x-k8s.io", Version: "v1beta2", Kind: "Cluster"}
 
 // Global harness state, initialized by TestMain.
 var (

--- a/test/e2e/testdata/capi-cluster-crd.yaml
+++ b/test/e2e/testdata/capi-cluster-crd.yaml
@@ -1,10 +1,18 @@
-# Minimal stand-in for the ClusterAPI Cluster CRD (cluster.x-k8s.io/v1beta1).
+# Minimal stand-in for the ClusterAPI Cluster CRD.
 #
 # The k8s-r8r ClusterAPI discovery provider deliberately reads Cluster
 # objects unstructured (no CAPI import), so the e2e suite does not install
 # ClusterAPI at all: this CRD provides just enough surface for the provider —
 # metadata labels, status.conditions via the status subresource, and the
 # <name>-kubeconfig Secret convention (created by the suite).
+#
+# Two versions are served on purpose. The provider negotiates the version to
+# watch from the discovery API (issue #28), and a CRD serving only v1beta1
+# would make that negotiation a no-op in e2e. This mirrors a CAPI 1.11+
+# management cluster: v1beta2 served and storage, v1beta1 still served but
+# deprecated. The operator must pick v1beta2. Both versions use
+# x-kubernetes-preserve-unknown-fields with the default "None" conversion
+# strategy, so no conversion webhook is involved.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -20,9 +28,27 @@ spec:
     singular: cluster
   scope: Namespaced
   versions:
-    - name: v1beta1
+    - name: v1beta2
       served: true
       storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+    - name: v1beta1
+      served: true
+      storage: false
+      deprecated: true
+      deprecationWarning: "cluster.x-k8s.io/v1beta1 Cluster is deprecated; use cluster.x-k8s.io/v1beta2 Cluster"
       subresources:
         status: {}
       schema:


### PR DESCRIPTION
Fixes #28.

## The failure this removes

`internal/discovery/capi` pinned `cluster.x-k8s.io/v1beta1`. CAPI schedules `v1beta1` unserved in 1.16, and at that point:

- the dynamic informer's list/watch gets a **404**, which the reflector treats as retryable and retries forever, so `HasSynced` never flips and `Start` blocks inside `cache.WaitForCacheSync` until shutdown — the `cluster informer cache never synced` error surfaces at *process exit*;
- readiness is hub-cache-only by design, so the pod stays **Ready**;
- `k8s_r8r_clusters` reads `0` from the *runtime manager* snapshot, indistinguishable from a genuinely empty fleet;
- annotated Secrets still materialize `Replication`s, with zero targets and no denial event.

Green pod, green probes, zero replication, no signal — on a scheduled upstream trigger.

## What changed

**Negotiation.** `resolveClusterGVR` asks the hub's discovery API which versions of `clusters.cluster.x-k8s.io` are served, intersects them with an explicit ordered list `[v1, v1beta2, v1beta1]`, and takes the first hit. Resolution happens in `Start`, not at construction, so an unreachable hub retries through the manager instead of crash-looping the factory. The negotiated version is logged once at info level — which is what makes future skew visible before it becomes an incident.

The list is explicit rather than the group's `preferredVersion` on purpose: `preferredVersion` would auto-adopt any future CAPI version, including one whose readiness-condition vocabulary this provider has never been validated against — trading "discovers nothing" for "reports every cluster not-ready", which is no better. The explicit list makes "which CAPI versions is this build validated for?" a readable constant.

**Two failure modes, deliberately different responses:**

| condition | response | why |
|---|---|---|
| resource served, but at no supported version | **fatal** — `Start` returns `capi: clusters.cluster.x-k8s.io serves none of [v1 v1beta2 v1beta1] (served: [...])`; the manager stops and the pod restarts with that in its logs | structural skew between this build and the hub; it will not resolve itself |
| resource absent, or hub unreachable | retry every 30s, `Watching() == false`, reason logged | ClusterAPI may be installed later — the documented kind quickstart deliberately runs a hub with none |

Collapsing the second into the first would crash-loop the operator on the fleet `docs/quickstart.md` tells people to build, and would break the e2e suite's install-then-apply-CRD order, while buying nothing: the condition shows up in `k8s_r8r_discovery_up` either way. Neither case is silent, which is the actual bug.

This does **not** conflict with `observability-operations`' "one spoke down must not make us unready": that requirement is about individual spokes, and per-cluster runtimes still provide that isolation. Readiness is untouched — still hub-informers-synced only. The pod does not go not-ready; on a structural skew it exits.

**Discovery health.** New `k8s_r8r_discovery_up{provider}` and `k8s_r8r_discovery_clusters{provider}`, sourced from the provider's own state and `List()`, wired through `telemetry.SetDiscoverySnapshot` (same injection pattern as `SetClusterSnapshot`, so `internal/telemetry` keeps no dependency on `internal/discovery`).

| `discovery_up` | `discovery_clusters` | meaning |
|---|---|---|
| 1 | 0 | discovery works, fleet is empty |
| 1 | n | healthy |
| 0 | 0 | discovery is not running — the alert worth writing |

`provider` is a bounded label (registry names, one value per process) and is added to the cardinality allowlist the telemetry test enforces.

**Bounded cache sync.** `WaitForCacheSync` now has a 2m timeout and reports `capi: clusters.cluster.x-k8s.io informer cache never synced within 2m0s` instead of hanging. Shutdown during the initial sync is not reported as a failure.

**Interface.** `discovery.Provider` gains `Watching() bool`. Without it, `List()` alone cannot distinguish a broken provider from an empty fleet — and a `main.go` type assertion with a `true` default would have re-introduced exactly the silent-success default this PR exists to remove.

## Spec

OpenSpec change `negotiate-capi-cluster-version`, amending two capabilities:

- **`cluster-discovery`** — the ClusterAPI-provider requirement was *silent on versioning*, so the pinned-GVR code was not strictly non-conformant. This tightens it to require resolving a served version across a supported set, plus the scenarios "serves no supported version → fail to start naming group/resource and served versions" and "ClusterAPI not installed yet → retry, report not-watching".
- **`observability-operations`** — the metrics minimum said "cluster runtime count", which `k8s_r8r_clusters` satisfies exactly. That metric is the one that cannot distinguish this failure from an empty fleet, which is how the gap slipped through a complete-looking inventory. The minimum now includes discovery health.

## Verification

- Verified in code, not assumed: `readyConditionTypes` accepts `ControlPlaneReady` **or** `ControlPlaneAvailable`, and `controlPlaneReady` reads `status.conditions[].type/.status` as strings via `unstructured.NestedSlice` — both condition shapes expose them at that path. `recordFromCluster` otherwise reads only `ObjectMeta`. Nothing in record translation is version-bound; `TestRecordFromClusterIsVersionIndependent` pins that.
- `resolveClusterGVR` unit-tested against a fake discovery client across 9 served-version sets: legacy-only, deprecated+current, current-only, GA present, unknown newer version ignored, unsupported-only (fatal), group absent (retryable), resource missing from every group version, resource on only one of the group's versions.
- `Start` tested both ways: returns the named error without blocking when no supported version is served; waits and returns nil on cancel when the resource is absent.
- `make test` green (220 tests). `make lint` reports 6 pre-existing `staticcheck` SA5011 findings in `internal/annotations/annotations_test.go` and `internal/engine/reconciler_test.go` — **confirmed identical on a clean `origin/main`** by stashing this branch and re-running; this change adds none.
- **e2e not run**: the Docker daemon was unavailable in this environment. `go vet -tags e2e ./test/e2e/...` compiles. The CRD now serves `v1beta2` (storage) + deprecated `v1beta1` so negotiation is genuinely exercised rather than short-circuited, the suite writes at `v1beta2`, and `TestCAPIVersionNegotiation` asserts the operator logged `cluster.x-k8s.io/v1beta2`. **This needs a `make test-e2e` run on a machine with docker before merge.**

Left out: #37 (`discovery.Options.Settings` never populated in production). Negotiation removes the need for a manual version escape hatch, and wiring settings through is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
