### PR TITLE
chore: exclude agent worktrees from golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,9 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      # Parallel agent runs create git worktrees here; linting a checkout of
+      # the repo from inside the repo reports every finding twice.
+      - \.claude/worktrees
 formatters:
   enable:
     - gofmt
@@ -70,3 +73,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - \.claude/worktrees


### PR DESCRIPTION
Running `make lint` locally while a parallel agent worktree exists under `.claude/worktrees/` reports every finding twice — once for the real file, once for the nested checkout. CI never sees this because it has no worktrees, so it presents as "lint fails on clean main" and sends people looking for a phantom regression.

Adds `\.claude/worktrees` to the exclusion paths for both linters and formatters. Verified: `make lint` goes from 6 issues (all under `.claude/worktrees/agent-*/`) to `0 issues.` with worktrees present.

No source change.