### PR TITLE
fix(discovery): populate Options.Settings from a --discovery-setting flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ release; they are called out under **Changed** or **Removed**.
 
 ### Added
 
+- **`--discovery-setting key=value`** manager flag (chart value
+  `discoverySettings`, a map) finally reaches
+  `discovery.Options.Settings` ([#37](https://github.com/moeritze/k8s-r8r/issues/37)).
+  The settings map was plumbed through the provider interface and read by the
+  `cluster-api` provider, but nothing in a deployed operator ever populated
+  it, so every provider setting was unreachable outside tests. The flag is
+  comma-separated and repeatable; the chart renders one flag per map entry. A
+  malformed entry (no `=`, or an empty key) fails startup instead of being
+  dropped, because a mistyped setting is indistinguishable from an unset one
+  once a provider reads it. Keys read by the `cluster-api` provider are
+  documented in `docs/quickstart.md`; today that is `namespace` (restrict the
+  ClusterAPI `Cluster` watch to a single namespace).
+
 - **`TargetsResolved` condition on `Replication`** reports whether a request
   resolved to any target: `True` once at least one target survives selector
   matching and policy evaluation, `False`/`PolicyDenied` when policy refused

--- a/charts/k8s-r8r/templates/deployment.yaml
+++ b/charts/k8s-r8r/templates/deployment.yaml
@@ -56,6 +56,12 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --discovery-provider={{ .Values.discoveryProvider }}
+        {{- /* One flag per entry (range over a map is key-sorted, so the
+               rendering is stable) — a single comma-joined value could not
+               carry a value containing a comma. */}}
+        {{- range $key, $value := .Values.discoverySettings }}
+        - {{ printf "--discovery-setting=%s=%v" $key $value | quote }}
+        {{- end }}
         - --hub-name={{ .Values.hubName }}
         - --allowed-kinds={{ join "," .Values.allowedKinds }}
         {{- with .Values.stripMetadataKeys }}

--- a/charts/k8s-r8r/values.yaml
+++ b/charts/k8s-r8r/values.yaml
@@ -33,6 +33,21 @@ replicaCount: 1
 # cluster-api.
 discoveryProvider: cluster-api
 
+# Provider-specific discovery settings (--discovery-setting key=value), as a
+# map. Keys are defined by the selected discoveryProvider; unknown keys are
+# ignored, and a malformed entry fails operator startup rather than being
+# silently dropped. Keys and values must not contain commas.
+#
+# cluster-api:
+#   namespace  Restrict the ClusterAPI Cluster watch to one namespace.
+#              Unset (the default) watches all namespaces. Set it when the
+#              fleet runs identically named Clusters in several namespaces,
+#              since discovery keys targets by Cluster name.
+#
+# discoverySettings:
+#   namespace: capi-system
+discoverySettings: {}
+
 # Source-cluster identity stamped onto replicas as the
 # r8r.io/source-cluster label (--hub-name).
 hubName: hub

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -126,6 +127,46 @@ func (s *stringListFlag) Set(v string) error {
 		if part = strings.TrimSpace(part); part != "" {
 			*s = append(*s, part)
 		}
+	}
+	return nil
+}
+
+// stringMapFlag is a flag.Value accumulating key=value pairs: repeatable and
+// comma-separated, so --discovery-setting=a=1,b=2 and --discovery-setting=a=1
+// --discovery-setting=b=2 are equivalent. A later entry wins for a repeated
+// key. Values may contain "=" (only the first one separates) but not ",".
+//
+// Unlike stringListFlag, a malformed entry is an error rather than a dropped
+// one: a mistyped setting is indistinguishable from an unset setting once the
+// provider reads it, so it would silently take the default and produce a
+// misconfigured operator that looks healthy.
+type stringMapFlag map[string]string
+
+// String implements flag.Value. Entries are sorted so the rendering is stable.
+func (m *stringMapFlag) String() string {
+	pairs := make([]string, 0, len(*m))
+	for k, v := range *m {
+		pairs = append(pairs, k+"="+v)
+	}
+	slices.Sort(pairs)
+	return strings.Join(pairs, ",")
+}
+
+// Set implements flag.Value.
+func (m *stringMapFlag) Set(v string) error {
+	for part := range strings.SplitSeq(v, ",") {
+		if part = strings.TrimSpace(part); part == "" {
+			continue
+		}
+		key, val, found := strings.Cut(part, "=")
+		key = strings.TrimSpace(key)
+		if !found || key == "" {
+			return fmt.Errorf("%q is not key=value with a non-empty key", part)
+		}
+		if *m == nil {
+			*m = stringMapFlag{}
+		}
+		(*m)[key] = strings.TrimSpace(val)
 	}
 	return nil
 }
@@ -302,6 +343,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var discoveryProviderName string
+	var discoverySettings stringMapFlag
 	var hubName string
 	var allowedKinds string
 	var stripMetadataKeys stringListFlag
@@ -326,6 +368,11 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&discoveryProviderName, "discovery-provider", "cluster-api",
 		"The cluster discovery provider to use (registered providers: cluster-api).")
+	flag.Var(&discoverySettings, "discovery-setting",
+		"Provider-specific setting as key=value, comma-separated and repeatable. "+
+			"Keys are defined by the selected --discovery-provider; unknown keys are ignored. "+
+			"The cluster-api provider reads \"namespace\" (restrict the ClusterAPI Cluster "+
+			"watch to one namespace; empty, the default, watches all).")
 	flag.StringVar(&hubName, "hub-name", "hub",
 		"The source-cluster identity stamped onto replicas.")
 	flag.StringVar(&allowedKinds, "allowed-kinds", "secrets,configmaps",
@@ -460,7 +507,10 @@ func main() {
 
 	// Discovery provider, selected by name from the registry providers
 	// register into (the capi import registers "cluster-api").
-	provider, err := discovery.New(discoveryProviderName, discovery.Options{HubConfig: hubCfg})
+	provider, err := discovery.New(discoveryProviderName, discovery.Options{
+		HubConfig: hubCfg,
+		Settings:  discoverySettings,
+	})
 	if err != nil {
 		setupLog.Error(err, "Failed to construct discovery provider", "provider", discoveryProviderName)
 		os.Exit(1)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"maps"
+	"testing"
+)
+
+// TestStringMapFlagAccumulates covers the two equivalent spellings of
+// --discovery-setting (repeated and comma-separated) and the value shapes the
+// providers care about.
+func TestStringMapFlagAccumulates(t *testing.T) {
+	cases := []struct {
+		name string
+		set  []string
+		want map[string]string
+	}{
+		{
+			name: "repeated flag",
+			set:  []string{"namespace=capi-system", "extra=on"},
+			want: map[string]string{"namespace": "capi-system", "extra": "on"},
+		},
+		{
+			name: "comma separated",
+			set:  []string{"namespace=capi-system,extra=on"},
+			want: map[string]string{"namespace": "capi-system", "extra": "on"},
+		},
+		{
+			name: "last entry wins for a repeated key",
+			set:  []string{"namespace=first", "namespace=second"},
+			want: map[string]string{"namespace": "second"},
+		},
+		{
+			name: "empty value is a real value, not a malformed entry",
+			set:  []string{"namespace="},
+			want: map[string]string{"namespace": ""},
+		},
+		{
+			name: "surrounding whitespace and empty entries are ignored",
+			set:  []string{" namespace = capi-system ,, "},
+			want: map[string]string{"namespace": "capi-system"},
+		},
+		{
+			name: "only the first = separates",
+			set:  []string{"key=a=b"},
+			want: map[string]string{"key": "a=b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got stringMapFlag
+			for _, v := range tc.set {
+				if err := got.Set(v); err != nil {
+					t.Fatalf("Set(%q) returned an unexpected error: %v", v, err)
+				}
+			}
+			if !maps.Equal(got, tc.want) {
+				t.Errorf("settings = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStringMapFlagRejectsMalformed pins the deliberate difference from
+// stringListFlag: a setting that cannot be parsed fails startup instead of
+// being dropped into an indistinguishable "unset".
+func TestStringMapFlagRejectsMalformed(t *testing.T) {
+	for _, v := range []string{"namespace", "=capi-system", " =x", "ok=1,broken"} {
+		t.Run(v, func(t *testing.T) {
+			var m stringMapFlag
+			if err := m.Set(v); err == nil {
+				t.Fatalf("Set(%q) succeeded, want an error; got %v", v, m)
+			}
+		})
+	}
+}
+
+// TestStringMapFlagString checks the flag renders deterministically, which is
+// what --help and the flag package's default-value detection read.
+func TestStringMapFlagString(t *testing.T) {
+	var empty stringMapFlag
+	if s := empty.String(); s != "" {
+		t.Errorf("empty flag String() = %q, want \"\"", s)
+	}
+
+	m := stringMapFlag{"b": "2", "a": "1"}
+	if s := m.String(); s != "a=1,b=2" {
+		t.Errorf("String() = %q, want \"a=1,b=2\"", s)
+	}
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,9 +98,34 @@ Useful values (see `charts/k8s-r8r/values.yaml` for all):
 | Value | Flag | Default |
 |---|---|---|
 | `discoveryProvider` | `--discovery-provider` | `cluster-api` |
+| `discoverySettings` | `--discovery-setting` | `{}` |
 | `hubName` | `--hub-name` | `hub` |
 | `allowedKinds` | `--allowed-kinds` | `[secrets, configmaps]` |
 | `spokeResync` | `--spoke-resync` | engine default (10h) |
+
+### Discovery provider settings
+
+`discoverySettings` is a map of provider-specific settings; the chart renders
+one `--discovery-setting key=value` argument per entry (the flag is also
+comma-separated and repeatable when you run the manager directly). Which keys
+mean something is up to the selected `discoveryProvider` — unknown keys are
+ignored, but a malformed entry (no `=`, or an empty key) fails operator
+startup rather than being silently dropped, so a typo is loud.
+
+Keys read by the `cluster-api` provider:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `namespace` | *(empty)* | Restrict the ClusterAPI `Cluster` watch to one namespace. Empty watches all namespaces. |
+
+Discovery keys target clusters by `Cluster` object name, so a fleet that runs
+identically named `Cluster` objects in several namespaces should scope the
+provider to one namespace to keep those names unique:
+
+```sh
+helm upgrade k8s-r8r charts/k8s-r8r --reuse-values \
+  --set discoverySettings.namespace=capi-system
+```
 
 ## 3. Annotate a Secret — and watch default deny
 


### PR DESCRIPTION
`discovery.Options.Settings` is plumbed through the provider `Factory` interface and read by the `cluster-api` provider, but production constructed the provider as `discovery.New(name, discovery.Options{HubConfig: hubCfg})` — no `Settings` map, no flag, no chart value. Every provider setting was unreachable in a deployed operator; the mechanism only ever worked from tests.

Fixes #37.

## What changed

- **`--discovery-setting key=value`** manager flag (`cmd/main.go`), backed by a new `stringMapFlag` modelled on the existing `stringListFlag` that `--strip-metadata-keys` uses: comma-separated **and** repeatable, so `--discovery-setting=a=1,b=2` and `--discovery-setting=a=1 --discovery-setting=b=2` are equivalent. A later entry wins for a repeated key; only the first `=` in an entry separates, so values may contain `=`.
- The flag value is passed into `discovery.Options{HubConfig: …, Settings: …}` at the construction site.
- **Malformed entries fail startup.** An entry with no `=` or an empty key returns an error from `Set`, so `flag.Parse` exits with `invalid value … for flag -discovery-setting`. This is the one deliberate difference from `stringListFlag`, which drops empty entries: once a provider reads a *mistyped* setting it is indistinguishable from an *unset* one, so a typo would silently take the default and yield a misconfigured operator that looks perfectly healthy.
- **Chart:** new `discoverySettings` map value; `templates/deployment.yaml` renders **one flag per map entry** (Helm's `range` over a map is key-sorted, so the rendering is stable) rather than one comma-joined value — that keeps a value containing a comma expressible.
- **Docs:** `docs/quickstart.md` — new "Discovery provider settings" section with the supported-key table, plus a `discoverySettings` row in the useful-values table. `CHANGELOG.md` entry under `## [Unreleased]` → `### Added`.
- **Tests:** `cmd/main_test.go` (new — `cmd` had no test file) covers both spellings, last-entry-wins, empty-value-is-a-real-value, whitespace/empty-entry tolerance, first-`=`-only splitting, the four malformed shapes, and the deterministic `String()` rendering the flag package's default-value detection reads.

## Setting keys now genuinely reachable

| Provider | Key | Meaning |
|---|---|---|
| `cluster-api` | `namespace` | Restrict the ClusterAPI `Cluster` watch to one namespace. Empty (default) watches all. |

That is the complete set the code reads today — `capi.SettingNamespace` is the only `o.Setting(...)` call in the tree. Unknown keys stay ignored by design (the provider decides what it reads); it is only the *shape* of an entry that is validated centrally.

This is also the missing escape hatch for #28: if CAPI discovery ever cannot negotiate a served API version, a settings-supplied override is the manual workaround, and until now there was nothing to supply it with. The key itself is not added here (the provider does not read one yet) — this PR builds the channel.

## No OpenSpec change — deliberately

The `cluster-discovery` spec is **not** silent on this, and that is precisely why no delta is needed. Its "Pluggable discovery interface" requirement already states:

> Provider choice and configuration SHALL be operator deployment configuration.

The spec was already right; the implementation was short of it — provider *choice* was deployment configuration, provider *configuration* was not. This PR closes that gap rather than changing required behaviour, so there is nothing to amend in `openspec/specs/cluster-discovery/spec.md` and no scenario to add. Creating a change here would be ceremony, not spec work.

## Verification

- `make test` — pass, all packages (`cmd` 13 tests).
- `helm lint charts/k8s-r8r` — pass. Rendered both ways: default renders no `--discovery-setting` arg at all; `--set discoverySettings.namespace=capi-system` renders `- "--discovery-setting=namespace=capi-system"`.
- `golangci-lint run ./cmd/...` — **0 issues**.
- A full `make lint` in this worktree reports 6 pre-existing `SA5011` staticcheck findings in `internal/annotations/annotations_test.go` and `internal/engine/reconciler_test.go`. `git diff origin/main -- internal/` is **empty** — those files are byte-identical to `main` and untouched by this PR, so they are not regressions and are left alone.
- `make test-e2e` **not run — Docker is not available in this environment.** Relying on CI for the kind-fleet suite. The change is startup wiring in `cmd/main.go` plus a chart arg, with no engine/transport behaviour change, so e2e risk is low; the chart render was verified by hand as above.

## Vault follow-up (not done here — `obsidian/` is owned by another agent this session)

Per the repo's docs-are-part-of-done contract, the vault still needs:

- The cluster-discovery note: document `--discovery-setting` / `discoverySettings` as the provider-configuration channel, and that the settings map is what makes `discovery.Options.Settings` reachable.
- The CAPI provider note: record `namespace` as the one supported key today, and link it to the #28 version-negotiation note as the intended override channel.
- Whichever note lists manager flags / chart values: add the flag and value.
- `graphify export obsidian --dir obsidian/graph` after the graph rebuild.

## Territory

Touched only `cmd/main.go`, `cmd/main_test.go`, `charts/k8s-r8r/{values.yaml,templates/deployment.yaml}`, `docs/quickstart.md`, `CHANGELOG.md`. Nothing under `internal/`, `obsidian/`, or `docs/security.md`.
