### PR TITLE
docs(obsidian): fold #27, #30 and #34 into the vault as behaviour

### DIFF
--- a/obsidian/architecture.md
+++ b/obsidian/architecture.md
@@ -33,8 +33,8 @@ Hub-spoke, push-based. Everything runs on the hub; spokes only receive replicas 
 | D4 | Default deny, union, allowlists only | deny-precedence kills policy engines — see [[policy-model]] |
 | D5 | Narrow spoke SA bootstrap | blast radius; retrofit never happens — see [[security-model]] |
 | D6 | Webhook advisory, controller authoritative | `failurePolicy: Fail` would block secret writes |
-| D7 | Conflicts Fail/Overwrite/Adopt, no auto-rename | silent rename breaks name-based consumers — caveats in [[replication-flow]] |
-| D8 | Capped status | etcd 1.5MB limit, no churn — see [[operations]] |
+| D7 | Conflicts Fail/Overwrite/Adopt, no auto-rename; effective policy = min(request, grant) | silent rename breaks name-based consumers; a grant alone must not take over a foreign object — see [[replication-flow#Conflict handling is a two-key turn\|two-key turn]] |
+| D8 | Capped status, one writer per condition | etcd 1.5MB limit, no churn; two writers on one condition is a status ping-pong — see [[operations]] |
 | D9 | Workqueue keyed (source, targetCluster) | slow cluster never blocks fanout; sharding-ready |
 | D10 | kubebuilder + controller-runtime, `r8r.io/v1alpha1` | ecosystem standard |
 

--- a/obsidian/development.md
+++ b/obsidian/development.md
@@ -10,7 +10,7 @@ kubebuilder project, module `github.com/moeritze/k8s-r8r`, API group `r8r.io/v1a
 
 ## Testing ladder
 
-1. **Unit + envtest** — `make test` (121 test functions, 237 cases with subtests; engine/request suites run against an envtest API server, spokes faked via recording Transport)
+1. **Unit + envtest** — `make test` (133 test functions, 275 cases with subtests; engine/request suites run against an envtest API server, spokes faked via recording Transport)
 2. **e2e** — `make test-e2e`: provisions a real kind fleet (`hack/kind-fleet.sh`, hub + 2 spokes), simulates ClusterAPI with a minimal CRD + status-patched `Cluster` objects + `--internal` kubeconfig Secrets, exercises full [[replication-flow]], [[cluster-discovery|cluster lifecycle]], and scale. `K8S_R8R_E2E_KEEP=1` keeps the fleet for debugging.
 3. **CI** (`.github/workflows/ci.yml`) — DCO, gitleaks, lint (custom golangci-lint w/ logcheck), test, build, e2e. Lint runs the same binary locally via `make lint`. Separately, `.github/workflows/govulncheck.yml` runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) on every PR **and** weekly on cron — the vuln DB moves even when the code doesn't, so a scheduled run is the point; it lives outside `ci.yml` so the schedule doesn't drag every CI job with it.
 

--- a/obsidian/drift-detection.md
+++ b/obsidian/drift-detection.md
@@ -21,13 +21,29 @@ watch event ──▶ compare r8r.io/source-hash annotation vs desired
 - Fallback resync (default 10h, `--spoke-resync`) catches missed events and dropped watches.
 - Informer lifecycle bound to cluster register/deregister.
 
-## Known gaps (open issues)
+## A correction is observable
 
-- **A correction leaves no trace** ([#30](https://github.com/moeritze/k8s-r8r/issues/30)). Drift is repaired promptly and then looks exactly like a routine reconcile: no event, no condition, no log line that distinguishes "found tampering and overwrote it" from "nothing to do". The one counter that exists, `k8s_r8r_drift_events_total`, counts *informer events on managed replicas* — including the engine's own apply echoes — so it cannot answer "has anything been tampering with my replicated secrets?". A fix is in flight; any signal must stay hash-only per [[security-model|secret-safe telemetry]].
-- **Blind if `managed-by` is rewritten** ([#36](https://github.com/moeritze/k8s-r8r/issues/36)). The spoke cache is label-filtered server-side, and `driftHandler.observe` returns early for anything without `app.kubernetes.io/managed-by: k8s-r8r`. If another controller, a GitOps tool, or an operator rewrites or removes that label on a replica, the object leaves the watch entirely while staying in `Replication.status.inventory` — edits and deletions then go unnoticed forever, and status keeps reporting the target ready. This is the metadata-only design working as specified, so the fix is not "watch more": candidates are resync-time `Transport.Get` verification of inventory members, or a signal when an inventory member is absent from the filtered cache.
+The corrective write is not silent any more ([#30](https://github.com/moeritze/k8s-r8r/issues/30)). `applyTarget` splits the write into its two sub-cases and only one of them is reported:
+
+| stored `source-hash` annotation | content hash | treated as |
+|---|---|---|
+| stale | differs | **drift** — counted + evented |
+| current | differs | **drift** — counted + evented |
+| stale | equal | **metadata repair** — written, silent |
+
+- `k8s_r8r_drift_corrections_total{cluster}` — replicas whose **content** the engine rewrote. This is the tamper signal.
+- `DriftCorrected` — a Warning event on the `Replication`, naming the replica ref and both hashes: `restored replica <cluster>/<ns>/<name>: observed content sha256:…, expected sha256:…`. Hashes only, never the diverging payload ([[security-model|secret-safe telemetry]]).
+
+**Why the annotation-only repair stays silent, deliberately.** A change to the *hashing rules* produces exactly that state fleet-wide on upgrade — the metadata-hygiene change ([#26](https://github.com/moeritze/k8s-r8r/issues/26)) did it, extending `cleanRawKeys` so every affected replica held a stale annotation over content that recomputed as equal. Counting those would turn an operator rollout into a fleet-wide tamper alarm, and one false spike is enough to teach an operator to ignore the metric permanently. Keeping it out buys the invariant worth alerting on: **a non-zero `k8s_r8r_drift_corrections_total` always means a replica's payload was actually wrong.** The cost is that hand-editing only the `r8r.io/source-hash` annotation is repaired without a signal — acceptable, because no payload was altered and the annotation is the engine's own cache, never trusted alone.
+
+**Read the rate off the metric, not the event stream.** `EventLimiter` suppresses an identical (object, reason, message) for five minutes, so drift recurring with the same hashes collapses into one event. That is the intended flood control ([[operations|rate-limited events]]), and it means the event stream understates recurrence by design. The counter is deliberately not rate-limited: event = "this happened, here is which object", metric = "and it is happening N times a minute".
+
+## Known gap (open issue)
+
+- **Blind if `managed-by` is rewritten** ([#36](https://github.com/moeritze/k8s-r8r/issues/36)). The spoke cache is label-filtered server-side, and `driftHandler.observe` returns early for anything without `app.kubernetes.io/managed-by: k8s-r8r`. If another controller, a GitOps tool, or an operator rewrites or removes that label on a replica, the object leaves the watch entirely while staying in `Replication.status.inventory` — edits and deletions then go unnoticed forever, and status keeps reporting the target ready. Note the correction signal above does not help here: an object that never reaches the reconcile never gets counted. This is the metadata-only design working as specified, so the fix is not "watch more": candidates are resync-time `Transport.Get` verification of inventory members, or a signal when an inventory member is absent from the filtered cache.
 
 ## Why metadata-only
 
 Memory stays bounded at fleet scale AND no fleet-wide secret data accumulates in hub caches — scale and [[security-model|security]] in one move. Cost: one watch connection per cluster per GVK (ArgoCD-proven pattern).
 
-Implementation: `internal/engine/drift.go` · spec: `openspec/specs/replication-engine` (drift requirement) · flow context: [[replication-flow]]
+Implementation: `internal/engine/drift.go` (watch + enqueue), `internal/engine/reconciler.go` (`applyTarget`: the corrective write, the counter and the event) · spec: `openspec/specs/replication-engine` (drift requirement) + `observability-operations` (metrics, rate-limited events) · flow context: [[replication-flow]]

--- a/obsidian/k8s-r8r.md
+++ b/obsidian/k8s-r8r.md
@@ -33,14 +33,16 @@ Open issues where behaviour is thinner than a reader would expect. Each is descr
 
 | # | Gap | Note |
 |---|---|---|
-| [#27](https://github.com/moeritze/k8s-r8r/issues/27) | Policy-denied and revoked `Replication`s report `Ready=True` — nothing to alert on *(fix in flight)* | [[replication-flow]], [[operations]] |
-| [#30](https://github.com/moeritze/k8s-r8r/issues/30) | Drift correction emits no event, condition, or usable metric *(fix in flight)* | [[drift-detection]], [[operations]] |
-| [#29](https://github.com/moeritze/k8s-r8r/issues/29) | Spoke RBAC scoped to `--allowed-kinds`, not to the policy universe | [[security-model]], [[cluster-discovery]] |
-| [#34](https://github.com/moeritze/k8s-r8r/issues/34) | `Overwrite` has no request-side consent — the documented two-key turn is one key | [[replication-flow]], [[policy-model]] |
+| [#29](https://github.com/moeritze/k8s-r8r/issues/29) | Spoke RBAC scoped to `--allowed-kinds`, not to the policy universe — full replica verbs in every spoke namespace, no `resourceNames` | [[security-model]], [[cluster-discovery]] |
+| [#31](https://github.com/moeritze/k8s-r8r/issues/31) | No `targets.namespaceSelector`: policy target namespaces are exact names only, while sources may use a selector | [[policy-model]] |
 | [#35](https://github.com/moeritze/k8s-r8r/issues/35) | `Adopt` rewrites `managed-by` (breaks Helm ownership) and revocation deletes the adopted object | [[replication-flow]], [[policy-model]] |
 | [#36](https://github.com/moeritze/k8s-r8r/issues/36) | Drift goes permanently blind if `managed-by` is rewritten on a replica | [[drift-detection]] |
 | [#37](https://github.com/moeritze/k8s-r8r/issues/37) | `discovery.Options.Settings` is never populated, so provider settings are unreachable | [[cluster-discovery]] |
 
+Closed since the last vault pass, now described as behaviour rather than listed here: [#27](https://github.com/moeritze/k8s-r8r/issues/27) (status truthfulness → [[replication-flow#5. Status: one writer per condition|condition ownership]]), [#30](https://github.com/moeritze/k8s-r8r/issues/30) (drift corrections are observable → [[drift-detection]]), [#34](https://github.com/moeritze/k8s-r8r/issues/34) (conflict two-key turn → [[replication-flow#Conflict handling is a two-key turn|conflict handling]]). #34 and #27 both change observable behaviour on upgrade — see [[operations#What to alert on|alerting]] and the breaking-change note in [[replication-flow]].
+
 ## Status
 
-v0 alpha, `v0.1.0-alpha.1` published (2026-09). Bootstrap change `bootstrap-k8s-r8r-operator` complete (36/36 tasks); `make test` green at 121 test functions / 237 cases, e2e green on the kind fleet. Five OpenSpec changes archived, their deltas promoted into `openspec/specs`. Since the release: foreign-ownership metadata stripping, CAPI API-version negotiation, core-v1 event recording, spoke-RBAC doc correction. Post-v1 topics: licensing model, contribution setup, distribution.
+v0 alpha, `v0.1.0-alpha.1` published (2026-09). Bootstrap change `bootstrap-k8s-r8r-operator` complete (36/36 tasks); `make test` green at 133 test functions / 275 cases, e2e green on the kind fleet. Five OpenSpec changes archived, their deltas promoted into `openspec/specs`. Since the release: foreign-ownership metadata stripping, CAPI API-version negotiation, core-v1 event recording, spoke-RBAC doc correction, truthful `Replication` status, observable drift corrections, request-side conflict consent. Post-v1 topics: licensing model, contribution setup, distribution.
+
+Two of those are **breaking on upgrade** and worth reading before rolling forward: `Replication`s that reported `Ready=True, 0/0 targets ready` now report `Ready=False`/`NoTargets`, and conflict handling now requires the `r8r.io/conflict-policy` annotation in addition to the policy grant.

--- a/obsidian/operations.md
+++ b/obsidian/operations.md
@@ -45,12 +45,15 @@ Note the pod stays **Ready** through all of these: readiness reflects hub inform
 
 ## Events
 
-Lifecycle transitions on sources and Replications (Replicated, NoTargets, PolicyDenied, Conflict, DriftCorrected, PolicyRevoked, ClusterGone, CleanedUp), rate-limited per object+reason (5m cooldown, changed messages pass) so flapping targets can't flood. [[security-model|Never any payload data]].
+Lifecycle transitions, rate-limited per object+reason (5m cooldown, changed messages pass) so flapping targets can't flood. [[security-model|Never any payload data]]. They land on two different objects, which matters when you go looking for them:
 
-Two of these are newer than the rest:
+- **On the `Replication`** (engine): `Replicated`, `Adopted`, `CleanedUp` (Normal); `NoTargets`, `PolicyDenied`, `Conflict`, `ConflictOverwritten`, `DriftCorrected`, `PolicyRevoked`, `ClusterGone` (Warning).
+- **On the annotated source object** (request controller): `KindNotEnabled`, `InvalidAnnotations`, `PolicyDenied`, `NameConflict` (Warning) — these fire before a `Replication` exists, or explain why one has fewer targets than asked.
 
-- **`NoTargets`** (Warning, on the `Replication`) — the `Ready` transition for a request that resolved to nothing. It replaced the spurious "Replicated 0/0 targets ready" success event a denied request used to emit on every reconcile ([[replication-flow#5. Status: one writer per condition|condition ownership]]).
-- **`DriftCorrected`** (Warning, on the `Replication`) — `restored replica <cluster>/<ns>/<name>: observed content sha256:…, expected sha256:…`. Only real content divergence; an annotation-only repair is silent by design.
+Two are newer than the rest:
+
+- **`NoTargets`** — the `Ready` transition for a request that resolved to nothing. It replaced the spurious "Replicated 0/0 targets ready" success event a denied request used to emit on every reconcile ([[replication-flow#5. Status: one writer per condition|condition ownership]]).
+- **`DriftCorrected`** — `restored replica <cluster>/<ns>/<name>: observed content sha256:…, expected sha256:…`. Only real content divergence; an annotation-only repair is silent by design.
 
 The 5m cooldown is the contract, not a bug — but it means the event stream **understates the rate** of recurring drift, because identical repeats coalesce. Read the rate off `k8s_r8r_drift_corrections_total`, which is deliberately not rate-limited. Event = "this happened, here is which object"; metric = "and it is happening N times a minute".
 

--- a/obsidian/operations.md
+++ b/obsidian/operations.md
@@ -8,6 +8,15 @@ tags: [functionality, operations]
 
 Replica desired/ready/failed gauges (per cluster) · policy/webhook denial counters (per dimension) · conflict, revocation, drift counters · cluster connectivity gauge (0 unreachable / 1 degraded / 2 reachable) · bootstrap + token rotation counters. Reconcile durations/workqueue depth come from controller-runtime built-ins. Cardinality bounded by test: labels only cluster/namespace/kind/provider — never object names.
 
+**The two drift counters answer different questions — do not conflate them.**
+
+| Metric | Counts | Use |
+|---|---|---|
+| `k8s_r8r_drift_events_total{cluster}` | spoke informer events on managed replicas, **the engine's own apply echoes included** | watch traffic volume. Rises on every legitimate source update — *do not alert on it* |
+| `k8s_r8r_drift_corrections_total{cluster}` | replicas whose **content** the engine actually rewrote | the tamper signal: non-zero always means a replica's payload was wrong |
+
+A source update moves the first and not the second. A replica edited on a spoke moves both. Caveats (silent annotation-only repair, event coalescing): [[drift-detection]].
+
 **Discovery health** (`k8s_r8r_discovery_up{provider}`, `k8s_r8r_discovery_clusters{provider}`) comes from the [[cluster-discovery|provider itself]], not from the runtime manager. `k8s_r8r_clusters` counts registered *runtimes* and reads 0 both when discovery is broken and when the fleet is genuinely empty — that ambiguity is what kept a total discovery outage invisible (#28). Read them together:
 
 | `discovery_up` | `discovery_clusters` | meaning |
@@ -30,22 +39,42 @@ kubectl -n k8s-r8r-system logs deploy/k8s-r8r | grep -i 'ClusterAPI'
 
 Note the pod stays **Ready** through all of these: readiness reflects hub informer sync only, by design. Discovery health lives in the metric, not in the probe.
 
+**Drift keeps recurring on one spoke.** The signature is *one* `DriftCorrected` event and a *climbing* `k8s_r8r_drift_corrections_total{cluster}` — the event coalesced, the counter did not. That pairing means the same replica is being rewritten over and over with the same content, which is a competing controller (another replicator, a GitOps tool reconciling the object back) or a human editing in a loop. Compare the `observed` hash in the event across occurrences: a stable observed hash points at a controller with its own desired state; a changing one points at hand edits. If the counter is flat but you expected corrections, check [#36](https://github.com/moeritze/k8s-r8r/issues/36) — a replica whose `managed-by` label was rewritten is invisible to drift detection entirely.
+
+**A `Replication` reports `Conflict` after upgrading from `v0.1.0-alpha.1`.** Conflict handling is now a two-key turn ([[replication-flow#Conflict handling is a two-key turn|why]]): a policy grant alone no longer takes over a pre-existing object. The `Conflict` message names which key is missing — if it says the request does not set `r8r.io/conflict-policy`, add that annotation to the source.
+
 ## Events
 
-Lifecycle transitions on sources and Replications (Replicated, PolicyDenied, Conflict, PolicyRevoked, ClusterGone, CleanedUp), rate-limited per object+reason (5m cooldown, changed messages pass) so flapping targets can't flood. [[security-model|Never any payload data]].
+Lifecycle transitions on sources and Replications (Replicated, NoTargets, PolicyDenied, Conflict, DriftCorrected, PolicyRevoked, ClusterGone, CleanedUp), rate-limited per object+reason (5m cooldown, changed messages pass) so flapping targets can't flood. [[security-model|Never any payload data]].
+
+Two of these are newer than the rest:
+
+- **`NoTargets`** (Warning, on the `Replication`) — the `Ready` transition for a request that resolved to nothing. It replaced the spurious "Replicated 0/0 targets ready" success event a denied request used to emit on every reconcile ([[replication-flow#5. Status: one writer per condition|condition ownership]]).
+- **`DriftCorrected`** (Warning, on the `Replication`) — `restored replica <cluster>/<ns>/<name>: observed content sha256:…, expected sha256:…`. Only real content divergence; an annotation-only repair is silent by design.
+
+The 5m cooldown is the contract, not a bug — but it means the event stream **understates the rate** of recurring drift, because identical repeats coalesce. Read the rate off `k8s_r8r_drift_corrections_total`, which is deliberately not rate-limited. Event = "this happened, here is which object"; metric = "and it is happening N times a minute".
 
 Recorded through the **core `v1` Event API** (`mgr.GetEventRecorderFor`), not `events.k8s.io/v1`: only the core recorder fills `firstTimestamp`/`lastTimestamp`/`count`, so `kubectl get events --sort-by=.lastTimestamp` orders them correctly and client-go's correlator aggregates repeats into a real count series. Trade-off: no `action` / `reportingController` fields. The `events.k8s.io` RBAC grant is kept regardless (a missing grant fails silently with 403), ratcheted by a repo audit test.
 
 ## Status discipline (D8)
 
-Summary counts + `Ready` condition; per-target detail only for non-ready targets, capped at 20 + overflow counter; status writes skipped when unchanged. 60-target e2e fanout: 13.9KB status, zero churn over 2 minutes. Full per-target truth lives in metrics/events.
+Summary counts + conditions; per-target detail only for non-ready targets, capped at 20 + overflow counter; status writes skipped when unchanged. 60-target e2e fanout: 13.9KB status, zero churn over 2 minutes. Full per-target truth lives in metrics/events.
 
-## What you cannot alert on yet
+"Zero churn" also depends on **one writer per condition** — `Ready` belongs to the engine, `TargetsResolved` to the request controller, `NotAuthoritative` to the authority reconciler. Two controllers writing one condition is not just an ambiguous verdict, it is a status-churn loop, because each write re-triggers the other's watch. Table and reasons: [[replication-flow#5. Status: one writer per condition|condition ownership]].
 
-Two blind spots to know about before wiring alerts; both are open issues with fixes in flight.
+## What to alert on
 
-- **`Ready` does not mean "it replicated"** ([#27](https://github.com/moeritze/k8s-r8r/issues/27)). `Ready` is computed from the failed-target count, and policy-denied targets never enter the target list — so a request that replicated nothing reports `Ready=True, AllTargetsReady, 0/0 targets ready`, identical to a healthy fanout. A typo'd cluster selector, a policy tightened too far, and a working replication all present the same. Alert instead on the `PolicyDenied` / `PolicyRevoked` events and on `k8s_r8r_policy_denials_total` / `k8s_r8r_revocations_total`. Same reason an Argo CD Lua health check keyed on `Ready` would render a no-op replication healthy. Mechanism: [[replication-flow]].
-- **A corrected drift is silent** ([#30](https://github.com/moeritze/k8s-r8r/issues/30)). No event, no condition, no distinguishable log line. `k8s_r8r_drift_events_total` is *not* the counter you want — it counts spoke informer events on managed replicas including the engine's own apply echoes, so it rises during normal fanout. There is currently no way to answer "has anything been tampering with my replicated secrets?" from the operator's output. Detail: [[drift-detection]].
+- **`Ready=False` on a `Replication`** is now the primary signal, and it is truthful: a request that asked for replication and got none reports `Ready=False`/`NoTargets`, whether the cause was a denial, a revocation, or a typo'd selector. Replicating nothing is no longer a vacuous success. An Argo CD Lua health check keyed on `Ready` is therefore safe to write.
+- **`TargetsResolved=False`** says *why* nothing resolved: `PolicyDenied` (candidates existed, policy refused them — fix the policy or the request) versus `NoTargets` (the `r8r.io/target-clusters` selector matched no *ready* cluster; policy was never consulted, so there is no denial event to look for).
+- **`k8s_r8r_drift_corrections_total` rising** — a replica's payload was actually wrong and got restored. Not `k8s_r8r_drift_events_total`, which rises during normal fanout.
+- Still useful as corroboration: the `PolicyDenied` / `PolicyRevoked` events and `k8s_r8r_policy_denials_total` / `k8s_r8r_revocations_total`.
+
+*Upgrading from `v0.1.0-alpha.1`:* Replications that reported `Ready: True` with `0/0 targets ready` flip to `Ready: False` on the first reconcile after upgrade. Nothing about what is replicated changes — only whether the object admits it.
+
+## What you still cannot alert on
+
+- **A replica whose `managed-by` label was rewritten** ([#36](https://github.com/moeritze/k8s-r8r/issues/36)). It leaves the label-filtered spoke cache, so it never reaches a reconcile: no drift event, no correction counter, and status keeps reporting the target ready. The correction signal above cannot cover it — an object the engine never looks at is never counted. Detail: [[drift-detection]].
+- **The gap between the spoke SA's grant and the policy universe** ([#29](https://github.com/moeritze/k8s-r8r/issues/29)). Nothing reports how much wider the bootstrapped RBAC is than what any policy permits; the only lever is the `--allowed-kinds` flag. Detail: [[security-model]].
 
 ## HA
 

--- a/obsidian/policy-model.md
+++ b/obsidian/policy-model.md
@@ -12,6 +12,7 @@ tags: [functionality, security]
 - **All dimensions, one policy**: a target is permitted only if a *single* policy matches source namespace, source kind, target cluster (labels), and target namespace. Dimensions never combine across policies.
 - **Union across policies**: any one fully-matching policy suffices.
 - Policy-side empty `clusterSelector` matches *all* clusters; request-side empty selector matches *none* (requests must be explicit, policies may be broad). Invalid selectors fail closed.
+- Namespace matching is **asymmetric today**: `sources` accepts either exact `namespaces` or a `namespaceSelector`, but `targets.namespaces` is exact names only — there is no `targets.namespaceSelector`, so a policy covering a growing set of target namespaces has to be edited every time one is added ([#31](https://github.com/moeritze/k8s-r8r/issues/31)).
 
 ```yaml
 apiVersion: r8r.io/v1alpha1
@@ -25,16 +26,31 @@ spec:
 ## Options (union when several policies permit)
 
 - `allowNamespaceCreation` — OR
-- `allowedConflictPolicies` — union, `Fail` always included; engine acts with the strongest granted (`Overwrite > Adopt > Fail`). The grant is the *only* input: there is no request-side conflict annotation to intersect with, so granting `Overwrite` grants it to every request the policy permits ([#34](https://github.com/moeritze/k8s-r8r/issues/34) — [[replication-flow|conflict caveats]])
+- `allowedConflictPolicies` — union, `Fail` always included; its strongest member is the **grant**, which is only one of the two keys. The engine acts on the weaker of the grant and the source's `r8r.io/conflict-policy` annotation, so granting `Overwrite` in a policy no longer grants it to every request that policy permits — each source must opt in per object ([[replication-flow#Conflict handling is a two-key turn|two-key turn]])
 - `revocationPolicy` — most conservative wins (`Retain` beats `Delete`)
 
 ## Revocation
 
 Policy is re-evaluated on **every** reconcile — reconcile-time enforcement is authoritative, the [[security-model|webhook]] is advisory only. Tightening a policy revokes live: `Delete` removes replicas; `Retain` freezes them with `PolicyRevoked`. No grandfathering.
 
-Two things to know before tightening in production:
+What a denial or a full revocation looks like once it settles:
+
+```yaml
+status:
+  summary: {desiredTargets: 0, readyTargets: 0, failedTargets: 0}
+  conditions:
+  - type: TargetsResolved       # request controller: why nothing resolved
+    status: "False"
+    reason: PolicyDenied
+  - type: Ready                 # engine: nothing is being replicated
+    status: "False"
+    reason: NoTargets
+```
+
+Both are durable and both live in status, so a fully denied or revoked request no longer reads as a healthy fanout ([#27](https://github.com/moeritze/k8s-r8r/issues/27); ownership table in [[replication-flow#5. Status: one writer per condition|replication-flow]]). Do **not** look for `PolicyRevoked` as the durable record: it is set only while at least one target is frozen under `Retain`, and is actively *removed* again once the revocation is fully processed. The `PolicyDenied` / `PolicyRevoked` events and `k8s_r8r_policy_denials_total` / `k8s_r8r_revocations_total` remain useful corroboration — see [[operations]].
+
+One thing to know before tightening in production:
 
 - `Delete` revocation walks the inventory, and objects taken over by `Adopt` are in it — so revocation deletes pre-existing objects k8s-r8r only adopted ([#35](https://github.com/moeritze/k8s-r8r/issues/35)). Prefer `Retain` wherever `Adopt` is granted.
-- Denial and full revocation both end with `desiredTargets: 0` and `Ready=True` once the engine's status pass runs — the separate `PolicyRevoked` condition is set only for the `Retain` case ([#27](https://github.com/moeritze/k8s-r8r/issues/27), being fixed; mechanism in [[replication-flow]]). Until then alert on the `PolicyDenied`/`PolicyRevoked` events and `k8s_r8r_policy_denials_total` / `k8s_r8r_revocations_total`, not on `Ready` — see [[operations]].
 
 Implementation: `internal/policy` (pure functions: `Evaluate`, `ResolveOptions`, `DetectRevocations`). Consumed by [[replication-flow|request controller + engine]]. Spec: `openspec/specs/replication-policy` · guide: `../docs/policies.md`

--- a/obsidian/replication-flow.md
+++ b/obsidian/replication-flow.md
@@ -17,13 +17,14 @@ metadata:
     r8r.io/target-clusters: "env=prod"        # label selector over cluster inventory; empty = NO clusters, no wildcard
     r8r.io/target-namespaces: "istio-system"  # default: source namespace
     r8r.io/target-name: "ca-cert"             # optional explicit rename — never automatic
+    r8r.io/conflict-policy: "Adopt"           # Fail | Adopt | Overwrite; absent means Fail
 ```
 
 Parsed by `internal/annotations` (shared with the [[security-model|webhook]]). Devs need zero new RBAC — you can only fan out what you can already write.
 
 ## 2. Materialization (request controller)
 
-`internal/controller/request` resolves selector × [[cluster-discovery|discovered inventory]] × [[policy-model|policy verdict]] into one operator-owned **`Replication`** object per source (origin `Annotation`, designed to admit a future `ReplicationSet`). Hand-authored Replications get `NotAuthoritative` and are ignored. Finalizer `r8r.io/finalizer` on the source blocks its deletion until replica cleanup completes.
+`internal/controller/request` resolves selector × [[cluster-discovery|discovered inventory]] × [[policy-model|policy verdict]] into one operator-owned **`Replication`** object per source (origin `Annotation`, designed to admit a future `ReplicationSet`). Its verdict on that resolution lands on the `TargetsResolved` condition (§5) and nowhere else — the controller never writes `Ready`. Hand-authored Replications get `NotAuthoritative` and are ignored. Finalizer `r8r.io/finalizer` on the source blocks its deletion until replica cleanup completes.
 
 ## 3. Fanout (engine)
 
@@ -32,18 +33,48 @@ Parsed by `internal/annotations` (shared with the [[security-model|webhook]]). D
 - **metadata hygiene**: foreign ownership / replication-intent keys are stripped too — `replicator.v1.mittwald.de/*`, `reflector.v1.k8s.emberstack.com/*`, `argocd.argoproj.io/*`, `app.kubernetes.io/instance`, `meta.helm.sh/*`, `kustomize.toolkit.fluxcd.io/*`, plus anything in `--strip-metadata-keys`. A replica carrying a foreign replicator's annotation would be a valid source for *that* controller, i.e. a fanout no [[policy-model|policy]] evaluated — the [[security-model|default-deny]] claim depends on this. Argo CD tracking keys are the mirror case: they make a replica prunable. Denylist, never an allowlist — a replicated sealed-secrets key must keep its own labels to work.
 - one predicate (`isStrippedKey`) feeds both the replica and the canonical hash. Stripping in only one of them would make `SourceHash(replica) != SourceHash(source)` forever → apply on every reconcile → [[drift-detection|drift]] event → enqueue → hot loop against every spoke.
 - applied via server-side apply (field manager `k8s-r8r`) over the push `Transport` using the spoke's [[security-model|bootstrapped SA token]]
-- conflicts with pre-existing unmanaged objects: `Fail` (default) / `Overwrite` (policy-gated) / `Adopt` (hash-equal only). An object already managed by k8s-r8r for a *different* source is always `Fail`, whatever the grant.
+- a replica whose stored hash no longer matches is rewritten — and the write's two sub-cases are *not* the same event: diverged **content** is a reported [[drift-detection|drift correction]], a merely stale `r8r.io/source-hash` annotation over unchanged content is repaired silently. See [[operations]] for what each one emits.
+- conflicts with pre-existing unmanaged objects: `Fail` (default) / `Adopt` (hash-equal only) / `Overwrite`, decided by the two-key turn below. An object already managed by k8s-r8r for a *different* source is always `Fail`, whatever either key says.
 - missing namespace: created only when policy sets `allowNamespaceCreation`; namespaces are never GC'd
 
-Two conflict-path caveats worth knowing before granting anything above `Fail`:
+### Conflict handling is a two-key turn
 
-- **`Overwrite` is one key, not two** ([#34](https://github.com/moeritze/k8s-r8r/issues/34)). `EffectiveConflictPolicy` (`internal/engine/conflict.go`) takes only the policy grant — there is no request-side conflict annotation to intersect with, despite `docs/security.md` and the engine spec describing a two-key turn. Granting `Overwrite` in a `ReplicationPolicy` grants it to every request that policy permits.
-- **`Adopt` is not as reversible as it reads** ([#35](https://github.com/moeritze/k8s-r8r/issues/35)). `Renderer.AdoptPatch` stamps `app.kubernetes.io/managed-by: k8s-r8r` onto the pre-existing object, which permanently breaks Helm's ownership check (`helm upgrade` then fails with `invalid ownership metadata`), and the adopted object joins the inventory below — so revocation with `revocationPolicy: Delete`, source deletion, or target deselection garbage-collects an object k8s-r8r never created.
+`EffectiveConflictPolicy` (`internal/engine/conflict.go`) acts on the **weaker** of what the request asks for and what policy grants, ranked `Fail` < `Adopt` < `Overwrite`:
+
+```
+effective = min( r8r.io/conflict-policy , strongest allowedConflictPolicies grant )
+```
+
+- **Absent annotation means `Fail`** — a request that says nothing consents to nothing. Anything the engine cannot name ranks as `Fail` on either side.
+- A `ReplicationPolicy` grant alone therefore never takes over an object k8s-r8r did not create; neither does an annotation alone.
+- The `Conflict` message names *which* key did not turn (`explainConflictKeys`), so "the request never opted in" reads differently from "no policy ever granted it". It surfaces twice: the per-target entry in `status.nonReadyTargets` and the `Conflict` warning event.
+- The [[security-model|webhook]] **denies** a malformed value (the key is part of the closed request contract) but only **warns** when no candidate policy could grant what was asked — such a request replicates fine and only its conflict handling falls back.
+
+**This is a breaking change since `v0.1.0-alpha.1`.** A source that relied on a policy-granted `Overwrite` **or** `Adopt` with no annotation now reports `Conflict` instead of taking the object over. Nothing is deleted or overwritten by the change — the new failure mode is always "did not take over", never the reverse. Fix is one annotation per source. Delivered by [#34](https://github.com/moeritze/k8s-r8r/issues/34).
+
+One conflict-path caveat still stands before granting anything above `Fail`:
+
+- **`Adopt` is not as reversible as it reads** ([#35](https://github.com/moeritze/k8s-r8r/issues/35)). `Renderer.AdoptPatch` stamps `app.kubernetes.io/managed-by: k8s-r8r` onto the pre-existing object, which permanently breaks Helm's ownership check (`helm upgrade` then fails with `invalid ownership metadata`), and the adopted object joins the inventory below — so revocation with `revocationPolicy: Delete`, source deletion, or target deselection garbage-collects an object k8s-r8r never created. Both keys must now turn before this happens, which narrows the blast radius but does not close the issue.
 
 ## 4. Tracking and cleanup
 
 Every replica lands in `Replication.status.inventory` — the GC source of truth. Cleanup triggers: source deleted, annotation removed, target deselected, policy revoked ([[policy-model#Revocation|revocation]]). Cluster deregistration releases inventory with a `ClusterGone` event (no credential remains to delete with) — deselect before deregistering for clean removal. Ongoing sync: [[drift-detection]].
 
-`Ready` on the `Replication` currently answers "did any target fail?", not "did what I asked for happen?". Denied targets are excluded from `spec.resolvedTargets` rather than reported as failures, so a fully denied request has *no* targets: the request controller does set `Ready=False, PolicyDenied` (`reportDenial`), but the engine's `buildStatus` recomputes `Ready` from the failed-target count on its next pass and — with `failed == 0` — overwrites it with `Ready=True, AllTargetsReady, 0/0 targets ready`. In status a fully denied request is then indistinguishable from a healthy fanout. The durable signals are the `PolicyDenied` event on the source and `k8s_r8r_policy_denials_total`; events expire, and status is what monitoring reads. Tracked and being fixed: [#27](https://github.com/moeritze/k8s-r8r/issues/27); see [[operations]].
+## 5. Status: one writer per condition
+
+Status is what monitoring reads — events expire — so every condition on a `Replication` has exactly **one** owner. Two writers on one condition is what [#27](https://github.com/moeritze/k8s-r8r/issues/27) was:
+
+| Condition | Owner | Question it answers |
+|---|---|---|
+| `Ready` | replication engine (`buildStatus`, `internal/engine/status.go`) | Is everything the engine was asked to do actually done? |
+| `TargetsResolved` | request controller (`reportTargetResolution`) | Did the request resolve to any target at all — and if not, why? |
+| `NotAuthoritative` | authority reconciler (`replication_controller.go`) | Is this a hand-authored `Replication` the operator refuses to act on? |
+| `PolicyRevoked` | replication engine | Is at least one target frozen under `revocationPolicy: Retain`? |
+
+`TargetsResolved` has three values: `True`/`TargetsResolved` once at least one (cluster, namespace) pair survives the selector *and* policy; `False`/`PolicyDenied` when candidates existed and policy refused every one; `False`/`NoTargets` when the request produced no candidate at all — a selector matching no *ready* cluster. That last case was previously silent in every channel: target resolution returns before policy is consulted, so there was no denial, no event, and no condition, and a typo'd selector stayed green forever.
+
+`Ready` is engine-owned and derived in `buildStatus` only. A **live** `Replication` with zero desired targets is now `Ready=False`/`NoTargets` — "asked to replicate, replicated nothing" is a failure, not a vacuous success. The branch is skipped while the object is being deleted, where zero desired targets is legitimate. `NoTargets` joins `PolicyDenied` as an event-worthy `Ready` transition, replacing the spurious "0/0 targets ready" success event the old ping-pong manufactured.
+
+Why the split matters beyond truthfulness: the request controller also watches `Replication` objects, so when both controllers wrote `Ready` each write re-triggered the other — unbounded status churn on every denied `Replication`, bounded only by the rate limiter and in violation of design D8 ([[architecture]]). Alerting guidance: [[operations]].
 
 Spec: `openspec/specs` (`replication-request`, `replication-engine`) · user docs: `../docs/annotations.md`

--- a/obsidian/security-model.md
+++ b/obsidian/security-model.md
@@ -32,13 +32,17 @@ So: reduction from fleet admin is real (no node/workload/RBAC control) but **nar
 
 Validating webhook (CEL matchConditions: fires only on objects carrying `r8r.io/` annotations; K8s ≥ 1.30) gives apply-time errors naming the failing policy dimension. `failurePolicy: Ignore` is **mandatory** — `Fail` would let operator downtime block all annotated secret writes. Security never depends on it: reconcile-time policy evaluation is authoritative; a bypassed webhook means worse error messages, never unauthorized replication.
 
+The deny/warn split follows from that doctrine: **deny** only what no policy could ever allow or what the shared parser cannot read (a malformed `r8r.io/conflict-policy`, say — the key is part of the closed request contract, so its value set is validated at admission); **warn** for everything advisory, including a `conflict-policy` no candidate policy permits. That request replicates normally and only its conflict handling falls back to the weaker key, so denying it would block a legitimate write over a hypothetical conflict.
+
 ## Secret-safe telemetry
 
 No log, event, condition, or metric ever contains payload data — hashes only. Enforced twice: runtime canary test + AST-walking static ratchet (`internal/telemetry/secretsafety_audit_test.go`) that fails on any `Data`/`StringData` reaching a formatting/event call. Checklist: `internal/telemetry/REVIEW_CHECKLIST.md`.
 
+The `DriftCorrected` event is the design under load: it must say *that* a replicated Secret was rewritten without saying *what* changed, so it carries the replica ref and the two full `sha256:` hashes and nothing else. Full hashes rather than prefixes — they are not secrets, they compare directly against `status.sourceHash` and the replica's annotation, and truncation would make distinct drifts collide into one rate-limiter key. Reaching for the object's `data` to describe the diff would trip the ratchet, correctly. See [[drift-detection]].
+
 ## Weaponization guards
 
-- `Overwrite` conflict mode could replace a victim cluster's secret → policy-gated, `Fail` default; replicas of a *different* source are never taken over ([[replication-flow]]).
+- `Overwrite` conflict mode could replace a victim cluster's secret → a genuine **two-key turn** since [#34](https://github.com/moeritze/k8s-r8r/issues/34): the engine acts on the *weaker* of the source's `r8r.io/conflict-policy` annotation and the policy grant, and an absent annotation means `Fail`. An admin grant alone no longer overwrites anything, and a request asking for `Overwrite` gets no more than its policies permit. Replicas of a *different* source are never taken over whatever either key says ([[replication-flow#Conflict handling is a two-key turn|mechanism]]). Note this cuts both ways for upgrades: fleets that relied on a grant-only `Overwrite` or `Adopt` now report `Conflict` until each source opts in.
 - Exfiltration via annotation → blocked by default-deny [[policy-model]]. Every destination a request names is re-evaluated against policy on every reconcile; an annotation can only narrow what a policy already permits, never widen it.
 - **Laundering a fanout through a second replicator** → blocked by [[replication-flow|metadata hygiene]]. A replica that inherited `replicator.v1.mittwald.de/replicate-to-clusters` (or the emberstack, Argo CD, Helm or Flux ownership keys) would be a valid *source* for that other controller — a second fanout no `ReplicationPolicy` ever saw. The engine strips those prefixes from the replica **and** from the canonical hash (`isStrippedKey`, `internal/engine/render.go`), operators can extend the denylist with `--strip-metadata-keys` / chart `stripMetadataKeys`. Fixed in [#26](https://github.com/moeritze/k8s-r8r/issues/26); the default-deny claim above depends on it.
 
@@ -48,8 +52,7 @@ Honest inventory of controls that are weaker than they read. None is an escalati
 
 | # | Gap | Where it bites |
 |---|---|---|
-| [#34](https://github.com/moeritze/k8s-r8r/issues/34) | `Overwrite` has **no request-side consent**. `EffectiveConflictPolicy` (`internal/engine/conflict.go`) takes only the policy grant, so the "two-key turn" `docs/security.md` describes does not exist — anyone who may annotate a source in an allowed namespace gets the strongest conflict behaviour the policy permits | [[replication-flow]], [[policy-model]] |
-| [#35](https://github.com/moeritze/k8s-r8r/issues/35) | `Adopt` rewrites `app.kubernetes.io/managed-by` on a **pre-existing** object (`Renderer.AdoptPatch`), permanently breaking Helm's ownership check, and files it in inventory — so a later revocation with `revocationPolicy: Delete` deletes an object k8s-r8r never created | [[replication-flow]], [[policy-model]] |
+| [#35](https://github.com/moeritze/k8s-r8r/issues/35) | `Adopt` rewrites `app.kubernetes.io/managed-by` on a **pre-existing** object (`Renderer.AdoptPatch`), permanently breaking Helm's ownership check, and files it in inventory — so a later revocation with `revocationPolicy: Delete` deletes an object k8s-r8r never created. The two-key turn now requires a per-source opt-in before this can happen, which narrows the blast radius but does not close the issue | [[replication-flow]], [[policy-model]] |
 | [#36](https://github.com/moeritze/k8s-r8r/issues/36) | Rewriting `managed-by` on a replica drops it out of the label-filtered spoke cache; drift detection then never sees it again while status still reports the target ready | [[drift-detection]] |
 | [#29](https://github.com/moeritze/k8s-r8r/issues/29) | Spoke RBAC scoped to `--allowed-kinds`, not to the policy universe (above) | [[cluster-discovery]] |
 


### PR DESCRIPTION
Second pass over the `obsidian/` vault. [#45](https://github.com/moeritze/k8s-r8r/pull/45) reconciled it with main; [#47](https://github.com/moeritze/k8s-r8r/pull/47), [#46](https://github.com/moeritze/k8s-r8r/pull/46) and [#48](https://github.com/moeritze/k8s-r8r/pull/48) landed after it, so three entries in that pass's "known gaps" tables are now shipped behaviour — and two of them break on upgrade, which a living documentation vault has to say out loud. Each of those PRs left an explicit handoff list in its comments; all three are applied, and the claims around them were re-verified against the code on `main` rather than trusted from the previous pass.

**Docs only — no Go files touched.** Territory: the entire `obsidian/` directory and nothing else.

## Per-note summary

| Note | Why it changed |
| --- | --- |
| `k8s-r8r.md` (hub) | Known-gaps table rebuilt: #27/#30/#34 removed (fixed), #31 added (was never listed), #29/#35/#36/#37 kept. New line pointing at where each closed issue is now described as behaviour. Status paragraph gains the three new fixes and a two-line breaking-change warning; test counts refreshed. |
| `replication-flow.md` | New **§5 "Status: one writer per condition"** with the ownership table, replacing the #27 gap paragraph. New **"Conflict handling is a two-key turn"** subsection: `effective = min(request, grant)`, absent annotation means `Fail`, which key the message names, webhook deny-vs-warn, and the breaking change stated plainly. `r8r.io/conflict-policy` added to the annotation block; the apply bullet now distinguishes a reported content correction from a silent annotation repair; §2 notes the request controller never writes `Ready`. |
| `drift-detection.md` | "A correction leaves no trace" (#30) replaced by **"A correction is observable"**: the three-row sub-case table, the counter, the `DriftCorrected` event shape, why the annotation-only repair is deliberately silent, and why the recurrence rate must be read off the metric, not the coalesced event stream. #36 kept, with a note that the new signal does not cover it. |
| `operations.md` | Metrics: two-drift-counter table with the "do not alert on `drift_events_total`" warning. Events: `NoTargets` and `DriftCorrected` added, plus the 5m-coalescing contract. Status discipline: one-writer-per-condition as a churn property, not just a truthfulness one. **"What you cannot alert on yet" → "What to alert on"** (`Ready` is now the primary signal) plus a shorter "what you still cannot". Two new troubleshooting entries: recurring drift on one spoke, and post-upgrade `Conflict`. |
| `policy-model.md` | `allowedConflictPolicies` is now one key of two. Revocation section shows the settled denial/revocation status block and warns that `PolicyRevoked` is *removed* once processed, so it is not the durable record. #31 added to Semantics (source namespaces accept a selector, target namespaces do not). |
| `security-model.md` | `Overwrite` moved from "weaponization guard with a known hole" to a genuine two-key turn, with the upgrade break. #34 row dropped from the gaps table; #35 row notes the narrowed blast radius. Webhook doctrine gains the deny-vs-warn rule the new key exercises. Secret-safe telemetry gains `DriftCorrected` as the worked example (full hashes, never payload). |
| `architecture.md` | D7 and D8 rows updated — D7 gains `min(request, grant)`, D8 gains one-writer-per-condition. |
| `development.md` | Test-ladder counts, stale for two sprints. |

A second commit completes the `operations.md` event inventory: `Adopted`, `ConflictOverwritten`, `KindNotEnabled`, `InvalidAnnotations` and `NameConflict` were all missing, and the list did not say which object each event lands on — four of those five fire on the annotated **source**, not on the `Replication`, which sends an operator to `kubectl describe` the wrong object. Enumerated from the code, not from the old list.

## Every claim verified against code

<details>
<summary>#47 — status truthfulness</summary>

- `Ready` derived in `buildStatus` **only**, other controllers' conditions carried over — `internal/engine/status.go:97-110`, doc comment `:87-96`.
- `Ready=False`/`NoTargets` for a live zero-target `Replication`, skipped while deleting — `internal/engine/status.go:163-172`.
- `TargetsResolved` written only by the request controller, three values — `internal/controller/request/controller.go:634-672` (`reportTargetResolution`, doc comment from :614).
- `NoTargets` joins `PolicyDenied` as an event-worthy `Ready` transition — `internal/engine/reconciler.go:908-913` (in `emitTransitionEvents`, :900).
- Condition constants and their exclusive-owner doc comments — `api/v1alpha1/replication_types.go:39-56, 78-90`.
- `NotAuthoritative` owner is the authority reconciler — `internal/controller/request/replication_controller.go:52-61`.
- `PolicyRevoked` set only when `revokedRetained`, actively removed otherwise — `internal/engine/status.go:184-194`.
- Settled `Delete`-revocation state (`Ready=False`/`NoTargets` + `TargetsResolved=False`/`PolicyDenied`) asserted as terminal, with a `Consistently` guard — `test/e2e/replication_test.go`, `TestPolicyDeleteRevocation`.

</details>

<details>
<summary>#46 — observable drift corrections</summary>

- Content-divergence split, counter and event — `internal/engine/reconciler.go:616-655`; `observed := SourceHash(existing)` / `corrected := observed != hash`.
- `k8s_r8r_drift_corrections_total{cluster}`, cluster-only label, registered — `internal/telemetry/metrics.go:93-101, 130-134, 386`.
- `drift_events_total` counts informer traffic including apply echoes — `internal/engine/drift.go:242-256` (`observe` increments on every managed-object event).
- Event message shape `<cluster>/<ns>/<name>` — `internal/engine/render.go:395-397` (`replicaRef`).
- 5m coalescing per (object, reason, message) — `internal/telemetry/events.go:25-26, 71-80`.
- The hashing-rule precedent that motivates the silent annotation repair is real: `cleanRawKeys` / `isStrippedKey` — `internal/engine/render.go:278-281, 306-321, 356-358`.

</details>

<details>
<summary>#48 — request-side conflict consent</summary>

- `EffectiveConflictPolicy` returns the weaker of request and grant — `internal/engine/conflict.go:85-99`; strength ranking `:59-70`; unknown values normalise to `Fail` `:103-110`.
- Request key read at decision time — `internal/engine/conflict.go:147`; `DecideConflict` takes the source object.
- Which-key-missing message — `internal/engine/conflict.go:181-210` (`explainConflictKeys`).
- `r8r.io/conflict-policy` in the closed request-key set, absent means `Fail` — `internal/annotations/annotations.go` (`KeyConflictPolicy`, `DefaultConflictPolicy = ConflictPolicyFail`, `parseConflictPolicy`, `RequestedConflictPolicy`).
- Webhook **denies** a malformed value, **warns** on an unsatisfiable one — `internal/webhook/webhook.go:167-172`, `internal/webhook/check.go` (`conflictPolicyWarning`).
- Foreign-source replicas are still always `Fail` regardless of either key — `internal/engine/conflict.go:134-144`.

</details>

<details>
<summary>Gaps confirmed still open</summary>

- **#29** (reopened) — `replicaVerbs = get,list,watch,create,update,patch,delete` on each allowlisted kind, no `ResourceNames`, ClusterRole/ClusterRoleBinding so every namespace: `internal/cluster/bootstrap.go:51-52, 89-121`. The in-code comment `:68-88` still describes both limitations as open. Only the *documentation* of this was ever done (PR #38), so the note stays as written.
- **#37** — `cmd/main.go:463` still constructs `discovery.Options{HubConfig: hubCfg}` with no `Settings`. PR #49 (`fix/37-discovery-settings-flag`) is **open, not merged**, so the note keeps this listed as a gap. If #49 lands before this merges, `cluster-discovery.md` §"Provider settings — not wired up yet" and the `operations.md` zero-clusters entry need a follow-up.
- **#36** — `driftHandler.observe` still returns early without the `managed-by` label: `internal/engine/drift.go:247-250`. No PR open. Kept as a gap, and `operations.md` now says explicitly that the new correction counter cannot cover it.
- **#31** — `targets.namespaces` is exact names only while `sources` has a `NamespaceSelector`: `api/v1alpha1/replicationpolicy_types.go:66-96`. Newly documented.
- **#35** — unchanged; note now records that the two-key turn narrows the blast radius without closing it.

</details>

## One stale claim found outside my territory — NOT fixed here

`README.md:53-57` is out of date and I did not touch it (README is outside this change's territory):

> That trial is generating findings faster than CI ever did: status conditions reporting `Ready=True` under policy denial, drift correction leaving no trace, replicas inheriting foreign GitOps ownership metadata, discovery pinned to a CAPI API version that upstream is removing, spoke RBAC wider than the policy universe. **They are tracked in the open [issues](https://github.com/moeritze/k8s-r8r/issues) and being worked through.**

Four of those five findings are closed, not open:

| Finding as written | Issue | State |
| --- | --- | --- |
| `Ready=True` under policy denial | #27 | **closed** (#47) |
| drift correction leaving no trace | #30 | **closed** (#46) |
| replicas inheriting foreign GitOps ownership metadata | #26 | **closed** (#40) |
| discovery pinned to a CAPI API version upstream is removing | #28 | **closed** (#41) |
| spoke RBAC wider than the policy universe | #29 | open (reopened) |

The list reads as a description of live problems, and the sentence after it asserts they are all still open. Only #29 is. This predates the three PRs above — #26 and #28 were already closed before them — so it is not fallout from this sprint, but it is the first thing a prospective adopter reads about the project's maturity. Worth a follow-up that either reframes the list as "findings the trial produced, since fixed" or trims it to #29. Deliberately left for the README's owner.

Everything else I checked while verifying is consistent with the code: `docs/policies.md`, `docs/annotations.md`, `docs/security.md`, `docs/quickstart.md`, `docs/gitops.md` and the rest of `README.md` — the three PRs updated their own doc surfaces correctly, including both upgrade notes.

## Link integrity

All **90** `[[wikilinks]]` across the 10 notes resolve, including every `#heading` anchor (a broken anchor is invisible until clicked, so the new section links were checked by name). Every note is reachable from the hub.

## Verification

- `make test` — **green**, exit 0, all packages including `internal/engine`, `internal/telemetry` (secret-safety AST audit + metric cardinality/inventory audits) and `internal/controller/request`.
- `make lint` — **0 issues** on this tree. Running it *from inside an agent worktree* pulls sibling worktrees into the analysis and reports 6 `SA5011` findings, all under `../agent-a047ff39be7a7463f/` (the #37 agent's in-flight test files) — the same artifact called out in #46 and #48. Linting a pristine `git archive` export of this branch reports `0 issues.`
- `graphify export obsidian --dir obsidian/graph` — **succeeded**, 2161 notes + `graph.canvas`. Gitignored (`.gitignore:51`), so nothing from it is in this diff. I did not run `graphify update`, which writes to `graphify-out/` — outside this change's territory.

Two agents are implementing #36 and #37 in parallel. Neither has merged; #49 is open for #37. Both remain listed as open gaps here.
