### PR TITLE
fix(engine): verify replica ownership instead of trusting the watch label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,45 @@ release; they are called out under **Changed** or **Removed**.
   `k8s_r8r_drift_events_total`, which counts spoke informer traffic (the
   operator's own apply echoes included) and therefore rises on ordinary
   source updates.
+- **`k8s_r8r_replica_ownership_lost_total{cluster,action}`** counts
+  inventoried replicas found without the `app.kubernetes.io/managed-by:
+  k8s-r8r` label — the spoke cache's own selector, so such a replica had
+  dropped out of the drift watch. `action` is `repaired`, `deleted` or
+  `orphaned`; alert on `orphaned`, which is the only one implying manual
+  cleanup. Paired with the `OwnershipRepaired`, `OwnershipStripped` and
+  `ReplicaOrphaned` warning events.
 
 ### Fixed
 
+- **A replica whose `app.kubernetes.io/managed-by` label is rewritten is no
+  longer lost** ([#36](https://github.com/moeritze/k8s-r8r/issues/36)).
+  That label is the server-side selector the spoke caches are built with, so
+  anything rewriting it on a spoke — another controller claiming the object, a
+  GitOps tool stamping its own ownership labels — evicted the replica from
+  drift detection entirely while it stayed in the `Replication`'s inventory.
+
+  Two consequences were worse than the lost watch coverage. The periodic
+  reconcile's live read misfiled the engine's own replica as a foreign object,
+  reported a `Conflict`, and **removed its inventory entry** — so a
+  `Replication` deleted afterwards could leave a copy of the replicated Secret
+  stranded on the spoke. Garbage collection's safety gate dropped such an
+  entry with no event and no metric at all.
+
+  The engine now classifies both ownership marks. An object still carrying
+  this replication's `r8r.io/source-uid` is recognised as its replica whatever
+  happened to `managed-by`: it is repaired (which restores the label and
+  returns the object to the watch), it keeps its inventory entry, and the
+  repair is reported. Objects carrying neither mark are still never touched,
+  but releasing their inventory entry is now reported instead of silent.
+  Verification uses the live reads the reconcile already performs, so there is
+  no additional API traffic on the healthy path.
+
+  **Behaviour change worth noting:** a replica whose ownership label was
+  rewritten is now **deleted** during cleanup, where it used to be abandoned.
+  This only ever applies to an object carrying this replication's own source
+  UID at the name its own inventory records. Detection is bounded by
+  `--spoke-resync` (10h by default), since the watch cannot see an object
+  outside its selector; see `docs/security.md`.
 - **Policy-denied and revoked `Replication` objects no longer report
   `Ready: True`** ([#27](https://github.com/moeritze/k8s-r8r/issues/27)).
   A `Replication` with zero resolved targets reported

--- a/docs/security.md
+++ b/docs/security.md
@@ -246,6 +246,66 @@ Two caveats when reading these:
 The event and the metric never carry payload: content is compared by hash
 only (see *Secret-safe telemetry* above).
 
+### The ownership label is the watch's membership predicate
+
+`app.kubernetes.io/managed-by: k8s-r8r` is not decoration. The spoke caches
+are built with a **server-side label selector** on it, which is what keeps hub
+memory bounded across a fleet (design D3 — the hub never caches replica
+payloads). A replica that loses that label leaves the informer completely: no
+add, no update, no delete is delivered for it again.
+
+That makes the label an attack surface, and not a subtle one. It is an
+`app.kubernetes.io/` convention label that plenty of other tooling writes:
+another controller claiming the object, a GitOps tool stamping its own
+ownership labels, an operator tidying labels by hand. Any of them evicts the
+replica from drift detection.
+
+The engine does not trust that label as its only evidence of ownership.
+`r8r.io/source-uid` carries the hub source object's UID; nothing but this
+operator writes it, and a UID is neither guessable nor reused when a source is
+deleted and recreated. Verification therefore keys on the source UID, using
+the live reads the reconcile already performs — no informer involved:
+
+| what the reconcile finds | what happens |
+|---|---|
+| both marks | normal drift comparison |
+| `r8r.io/source-uid` matches, `managed-by` rewritten | **repaired** — marks and content restored, which also returns the object to the cache's selector, so the watch works again |
+| neither mark | foreign object; the [conflict contract](#conflict-handling-as-a-security-control--design-d7) decides, and the default still refuses to touch it |
+
+| Signal | Fires when |
+|---|---|
+| `k8s_r8r_replica_ownership_lost_total{cluster,action="repaired"}` | a replica was outside the watch and has been put back |
+| `k8s_r8r_replica_ownership_lost_total{cluster,action="deleted"}` | a replica with a rewritten label was garbage-collected anyway |
+| `k8s_r8r_replica_ownership_lost_total{cluster,action="orphaned"}` | an inventory entry pointed at an unrecognisable object, so it was released **without deleting anything** |
+| `OwnershipRepaired` / `OwnershipStripped` / `ReplicaOrphaned` Warning events | the same three, naming the replica and the label |
+
+Read them like this:
+
+- **A climbing `repaired` count is a controller fight.** Something on that
+  spoke keeps taking the label back. Find it; the event names the label so
+  you know what to grep the other controller's config for.
+- **`orphaned` is the only one that implies manual work.** The engine will
+  not delete an object it cannot recognise, so an object may be left on the
+  spoke with nothing tracking it. Alert on this one.
+- A replica that lost its label **and** had its payload rewritten reports
+  *both* an ownership repair and a drift correction. That pair is the
+  strongest tampering evidence available; neither counter masks the other.
+
+Two limits worth knowing before you rely on this:
+
+- **Detection takes up to one resync interval.** The watch cannot see an
+  object outside its selector, so the periodic reconcile is what finds it —
+  `--spoke-resync`, 10h by default. Lower it if you need a tighter bound; it
+  moves the informer resync and the periodic reconcile together, which is the
+  correct coupling. The repair is self-healing, so the slow path is traversed
+  once per tampering event, not continuously.
+- **Replicas retained after a revocation are not verified.** Under
+  `revocationPolicy: Retain` the engine has undertaken not to write to the
+  replica any more. Repairing its ownership marks would break that
+  undertaking and would silently re-arm drift correction on material policy
+  no longer permits it to manage. A retained replica is released from the
+  engine's control; deleting it is your call, not the operator's.
+
 ## Supply chain
 
 A component that reads every Secret in a fleet is worth verifying before you

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -213,6 +214,75 @@ func (d *DriftDetector) Enqueue(key client.ObjectKey) {
 	case d.events <- event.GenericEvent{Object: rep}:
 	default:
 	}
+}
+
+// ReplicaOwnership classifies an object found at an inventoried replica's
+// name against the Replication that recorded it.
+//
+// The distinction exists because `app.kubernetes.io/managed-by: k8s-r8r` is
+// not just a label on a replica — it is the MEMBERSHIP PREDICATE OF THE DRIFT
+// WATCH. The spoke caches are built with a server-side selector on it and
+// driftHandler.observe filters on it again, so an object that loses the label
+// leaves the informer entirely: no add, no update, no delete is ever
+// delivered for it again (issue #36).
+//
+// It is also a conventional, widely-written label: it lives in the
+// `app.kubernetes.io/` namespace and plenty of other tooling stamps its own
+// value into it. `r8r.io/source-uid` does not have that problem — nothing but
+// this engine writes it, and a UID is neither guessable nor reused across a
+// delete/recreate of the source. That asymmetry is why recovery keys on the
+// source UID and not on managed-by.
+type ReplicaOwnership int
+
+const (
+	// OwnershipForeign: the object carries none of this Replication's
+	// ownership marks. It may belong to another controller, to another
+	// Replication, or to nobody. It is never repaired or taken over here —
+	// DecideConflict and its two-key consent contract govern it.
+	OwnershipForeign ReplicaOwnership = iota
+	// OwnershipManaged: the full marks are present — the managed-by label
+	// and a source-uid matching this Replication's source. The healthy state.
+	OwnershipManaged
+	// OwnershipStripped: the source-uid provenance label still identifies
+	// this Replication's source, but the managed-by label was rewritten or
+	// removed. The object is provably our replica AND is invisible to the
+	// drift watch. Restoring the label is what puts it back in the cache.
+	OwnershipStripped
+)
+
+// Event reasons for the ownership-verification outcomes. These are event
+// reasons, not per-target status reasons: neither outcome invents a slot in
+// status.targets (an orphaned entry is not a desired target, and a repaired
+// one is simply Ready again).
+const (
+	// ReasonOwnershipRepaired: an inventoried replica had lost its
+	// managed-by label and the engine restored its marks and content.
+	ReasonOwnershipRepaired = "OwnershipRepaired"
+	// ReasonOwnershipStripped: an inventoried replica had lost its
+	// managed-by label and was deleted during cleanup anyway, because its
+	// source-uid label still identified it.
+	ReasonOwnershipStripped = "OwnershipStripped"
+	// ReasonReplicaOrphaned: an inventory entry pointed at an object the
+	// engine cannot recognise, so the entry was released without deleting
+	// anything. Manual cleanup on the spoke may be needed.
+	ReasonReplicaOrphaned = "ReplicaOrphaned"
+)
+
+// ClassifyReplicaOwnership reports how an object's labels relate to the
+// Replication whose source has the given UID.
+//
+// Note the deliberate gap with IsManagedReplica, which requires both marks
+// and stays the GC safety gate and the conflict predicate: this function
+// exists precisely to name the case IsManagedReplica cannot express, "our
+// replica, relabelled".
+func ClassifyReplicaOwnership(labels map[string]string, sourceUID types.UID) ReplicaOwnership {
+	if labels[LabelSourceUID] != string(sourceUID) || sourceUID == "" {
+		return OwnershipForeign
+	}
+	if labels[LabelManagedBy] == ManagedByValue {
+		return OwnershipManaged
+	}
+	return OwnershipStripped
 }
 
 // driftHandler adapts informer events on one cluster into Replication

--- a/internal/engine/drift.go
+++ b/internal/engine/drift.go
@@ -251,9 +251,9 @@ const (
 )
 
 // Event reasons for the ownership-verification outcomes. These are event
-// reasons, not per-target status reasons: neither outcome invents a slot in
-// status.targets (an orphaned entry is not a desired target, and a repaired
-// one is simply Ready again).
+// reasons, not per-target status reasons: neither outcome adds an entry to
+// status.nonReadyTargets. An orphaned entry is not a desired target at all,
+// and a repaired replica is legitimately Ready again.
 const (
 	// ReasonOwnershipRepaired: an inventoried replica had lost its
 	// managed-by label and the engine restored its marks and content.
@@ -276,7 +276,9 @@ const (
 // exists precisely to name the case IsManagedReplica cannot express, "our
 // replica, relabelled".
 func ClassifyReplicaOwnership(labels map[string]string, sourceUID types.UID) ReplicaOwnership {
-	if labels[LabelSourceUID] != string(sourceUID) || sourceUID == "" {
+	// An empty source UID must never match an object that simply has no
+	// source-uid label — both read as "" through the map.
+	if sourceUID == "" || labels[LabelSourceUID] != string(sourceUID) {
 		return OwnershipForeign
 	}
 	if labels[LabelManagedBy] == ManagedByValue {

--- a/internal/engine/ownership_test.go
+++ b/internal/engine/ownership_test.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+// Coverage for replica ownership verification (issue #36): the drift watch's
+// label selector is `app.kubernetes.io/managed-by: k8s-r8r`, so a replica
+// whose label is rewritten leaves the informer entirely. The reconcile's own
+// live reads must recognise it as ours, repair it, and never lose track of it.
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	r8rv1alpha1 "github.com/moeritze/k8s-r8r/api/v1alpha1"
+	"github.com/moeritze/k8s-r8r/internal/telemetry"
+)
+
+// ownershipLostCount reads k8s_r8r_replica_ownership_lost_total for one
+// (cluster, action) pair (0 when it has never been touched).
+func ownershipLostCount(t *testing.T, cluster, action string) float64 {
+	t.Helper()
+	fams, err := metrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics: %v", err)
+	}
+	for _, mf := range fams {
+		if mf.GetName() != "k8s_r8r_replica_ownership_lost_total" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if hasLabel(m, "cluster", cluster) && hasLabel(m, "action", action) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// stripManagedBy removes the managed-by label from a replica in the spoke
+// store — what a GitOps tool stamping its own ownership labels, or an
+// operator tidying labels by hand, does to a replica.
+func stripManagedBy(t *testing.T, f *testFixture, cluster string) {
+	t.Helper()
+	replica := f.replica(cluster, f.ns)
+	if replica == nil {
+		t.Fatalf("no replica on %s to strip", cluster)
+		return
+	}
+	labels := replica.GetLabels()
+	delete(labels, LabelManagedBy)
+	replica.SetLabels(labels)
+	f.transport.put(cluster, replica)
+}
+
+// putForeignObject replaces whatever is at the replica's name with an object
+// carrying none of this replication's ownership marks.
+func putForeignObject(f *testFixture, cluster string) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(secretGVK)
+	obj.SetNamespace(f.ns)
+	obj.SetName("web-creds")
+	obj.SetLabels(map[string]string{LabelManagedBy: "argocd"})
+	obj.Object["data"] = map[string]any{"password": b64("somebody-elses")}
+	f.transport.put(cluster, obj)
+}
+
+// deselectAllTargets empties spec.resolvedTargets, which sends every
+// inventory entry through the GC path.
+func deselectAllTargets(t *testing.T, f *testFixture) {
+	t.Helper()
+	fresh := &r8rv1alpha1.Replication{}
+	if err := hubClient.Get(testCtx, client.ObjectKey{Namespace: f.ns, Name: "rep"}, fresh); err != nil {
+		t.Fatal(err)
+	}
+	fresh.Spec.ResolvedTargets = nil
+	if err := hubClient.Update(testCtx, fresh); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The classification is what separates "our replica, relabelled" from "not
+// ours". IsManagedReplica cannot express the middle row, which is why the
+// engine used to file a stripped replica as a foreign conflict.
+func TestClassifyReplicaOwnership(t *testing.T) {
+	const uid = types.UID("11111111-2222-3333-4444-555555555555")
+	for _, tc := range []struct {
+		name   string
+		labels map[string]string
+		want   ReplicaOwnership
+	}{
+		{
+			name:   "both marks present",
+			labels: map[string]string{LabelManagedBy: ManagedByValue, LabelSourceUID: string(uid)},
+			want:   OwnershipManaged,
+		},
+		{
+			name:   "managed-by removed",
+			labels: map[string]string{LabelSourceUID: string(uid)},
+			want:   OwnershipStripped,
+		},
+		{
+			name:   "managed-by rewritten by another controller",
+			labels: map[string]string{LabelManagedBy: "argocd", LabelSourceUID: string(uid)},
+			want:   OwnershipStripped,
+		},
+		{
+			name:   "source-uid of a different source",
+			labels: map[string]string{LabelManagedBy: ManagedByValue, LabelSourceUID: "some-other-uid"},
+			want:   OwnershipForeign,
+		},
+		{
+			name:   "no labels at all",
+			labels: nil,
+			want:   OwnershipForeign,
+		},
+		{
+			name:   "source-uid removed leaves nothing to key recovery on",
+			labels: map[string]string{LabelManagedBy: ManagedByValue},
+			want:   OwnershipForeign,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyReplicaOwnership(tc.labels, uid); got != tc.want {
+				t.Errorf("ClassifyReplicaOwnership() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// An empty source UID must never make an unlabelled object look like ours.
+func TestClassifyReplicaOwnership_EmptySourceUIDIsNeverOurs(t *testing.T) {
+	if got := ClassifyReplicaOwnership(map[string]string{}, ""); got != OwnershipForeign {
+		t.Errorf("empty UID against empty labels = %v, want OwnershipForeign", got)
+	}
+	if got := ClassifyReplicaOwnership(map[string]string{LabelSourceUID: ""}, ""); got != OwnershipForeign {
+		t.Errorf("empty UID against empty source-uid label = %v, want OwnershipForeign", got)
+	}
+}
+
+// Issue #36, the core case: a replica whose managed-by label was rewritten is
+// invisible to the drift watch. The reconcile's live read must recognise it
+// as ours, restore the label (which returns it to the cache's selector), keep
+// its inventory entry, and report the repair — not file it as a conflict and
+// drop the entry.
+func TestReconcile_StrippedOwnershipLabelIsRepairedAndReported(t *testing.T) {
+	const cluster = "ownership-repair-spoke"
+	f := newFixture(t, "hunter2", []r8rv1alpha1.ResolvedTarget{{ClusterName: cluster}}, cluster)
+	f.policy(nil, nil)
+
+	f.reconcile()
+	f.drainEvents()
+	before := ownershipLostCount(t, cluster, telemetry.OwnershipRepaired)
+	beforeDrift := driftCorrectionCount(t, cluster)
+
+	stripManagedBy(t, f, cluster)
+	_, rep := f.reconcile()
+
+	repaired := f.replica(cluster, f.ns)
+	if repaired == nil {
+		t.Fatal("replica gone after repair")
+	}
+	if got := repaired.GetLabels()[LabelManagedBy]; got != ManagedByValue {
+		t.Errorf("managed-by label not restored: %q", got)
+	}
+	if got := ClassifyReplicaOwnership(repaired.GetLabels(), f.secret.UID); got != OwnershipManaged {
+		t.Errorf("replica not back under management: %v", got)
+	}
+	if len(rep.Status.Inventory) != 1 {
+		t.Fatalf("inventory entry lost for a replica the engine created: %+v", rep.Status.Inventory)
+	}
+	if got := ownershipLostCount(t, cluster, telemetry.OwnershipRepaired); got != before+1 {
+		t.Errorf("ownership repairs = %v, want %v", got, before+1)
+	}
+	// Content never diverged, so the drift-correction counter's contract
+	// ("a non-zero value means the payload was actually wrong") holds.
+	if got := driftCorrectionCount(t, cluster); got != beforeDrift {
+		t.Errorf("a metadata-only ownership repair moved the drift counter: %v, want %v", got, beforeDrift)
+	}
+
+	evs := f.drainEvents()
+	if eventsContaining(evs, r8rv1alpha1.ReasonConflict) {
+		t.Errorf("our own relabelled replica was reported as a conflict: %v", evs)
+	}
+	var msg string
+	for _, e := range evs {
+		if strings.Contains(e, ReasonOwnershipRepaired) {
+			msg = e
+		}
+	}
+	if msg == "" {
+		t.Fatalf("no %s event: %v", ReasonOwnershipRepaired, evs)
+	}
+	if !strings.Contains(msg, "Warning") {
+		t.Errorf("%s is not a Warning: %q", ReasonOwnershipRepaired, msg)
+	}
+	if !strings.Contains(msg, replicaRef(cluster, f.ns, "web-creds")) {
+		t.Errorf("event does not name the replica: %q", msg)
+	}
+	// The operator's next action is finding what writes the label, so the
+	// event has to name it.
+	if !strings.Contains(msg, LabelManagedBy) {
+		t.Errorf("event does not name the rewritten label: %q", msg)
+	}
+	for _, leak := range []string{"hunter2", b64("hunter2")} {
+		if strings.Contains(msg, leak) {
+			t.Errorf("event leaks payload %q: %q", leak, msg)
+		}
+	}
+}
+
+// Ready must be truthful after the repair: the replica really does match the
+// source again.
+func TestReconcile_RepairedReplicaStaysReady(t *testing.T) {
+	const cluster = "ownership-ready-spoke"
+	f := newFixture(t, "hunter2", []r8rv1alpha1.ResolvedTarget{{ClusterName: cluster}}, cluster)
+	f.policy(nil, nil)
+	f.reconcile()
+
+	stripManagedBy(t, f, cluster)
+	_, rep := f.reconcile()
+
+	cond := readyCondition(rep)
+	if cond == nil || cond.Status != "True" {
+		t.Fatalf("Ready condition after repair = %+v, want True", cond)
+	}
+	if rep.Status.Summary.ReadyTargets != 1 || rep.Status.Summary.FailedTargets != 0 {
+		t.Errorf("summary after repair = %+v", rep.Status.Summary)
+	}
+}
+
+// The two signals compose: a replica that lost its label AND had its payload
+// rewritten reports both, so neither masks the other. That pair is the
+// strongest tampering evidence the operator gets.
+func TestReconcile_StrippedLabelWithDivergedContentReportsBoth(t *testing.T) {
+	const cluster = "ownership-drift-spoke"
+	f := newFixture(t, "hunter2", []r8rv1alpha1.ResolvedTarget{{ClusterName: cluster}}, cluster)
+	f.policy(nil, nil)
+
+	f.reconcile()
+	f.drainEvents()
+	beforeOwn := ownershipLostCount(t, cluster, telemetry.OwnershipRepaired)
+	beforeDrift := driftCorrectionCount(t, cluster)
+
+	tamperReplicaPayload(t, f, cluster, b64("tampered"))
+	stripManagedBy(t, f, cluster)
+	f.reconcile()
+
+	if got := replicaPassword(t, f.replica(cluster, f.ns)); got != b64("hunter2") {
+		t.Errorf("content not restored: %q", got)
+	}
+	if got := ownershipLostCount(t, cluster, telemetry.OwnershipRepaired); got != beforeOwn+1 {
+		t.Errorf("ownership repairs = %v, want %v", got, beforeOwn+1)
+	}
+	if got := driftCorrectionCount(t, cluster); got != beforeDrift+1 {
+		t.Errorf("drift corrections = %v, want %v", got, beforeDrift+1)
+	}
+
+	evs := f.drainEvents()
+	if !eventsContaining(evs, ReasonOwnershipRepaired) {
+		t.Errorf("no %s event: %v", ReasonOwnershipRepaired, evs)
+	}
+	if !eventsContaining(evs, "DriftCorrected") {
+		t.Errorf("no DriftCorrected event: %v", evs)
+	}
+	for _, e := range evs {
+		for _, leak := range []string{"hunter2", "tampered", b64("hunter2"), b64("tampered")} {
+			if strings.Contains(e, leak) {
+				t.Errorf("event leaks payload %q: %q", leak, e)
+			}
+		}
+	}
+}
+
+// Regression guard for the two-key conflict contract (#34): ownership
+// verification must not become a back door. An object with neither mark is
+// still a foreign object, and the default effective conflict policy still
+// refuses to touch it.
+func TestReconcile_ForeignObjectAtReplicaNameStillConflicts(t *testing.T) {
+	const cluster = "ownership-foreign-spoke"
+	f := newFixture(t, "hunter2", []r8rv1alpha1.ResolvedTarget{{ClusterName: cluster}}, cluster)
+	f.policy(nil, nil)
+	f.reconcile()
+	f.drainEvents()
+
+	putForeignObject(f, cluster)
+	_, rep := f.reconcile()
+
+	if got := replicaPassword(t, f.replica(cluster, f.ns)); got != b64("somebody-elses") {
+		t.Errorf("foreign object was overwritten: %q", got)
+	}
+	if eventsContaining(f.drainEvents(), ReasonOwnershipRepaired) {
+		t.Error("a foreign object was repaired as if it were ours")
+	}
+	if len(rep.Status.NonReadyTargets) != 1 || rep.Status.NonReadyTargets[0].Reason != r8rv1alpha1.ReasonConflict {
+		t.Errorf("non-ready targets = %+v, want a Conflict", rep.Status.NonReadyTargets)
+	}
+}
+
+// GC of a replica whose ownership label was rewritten: it is still a copy of
+// the source that this Replication created, so cleanup must remove it.
+// Abandoning it is what strands credential material on a spoke.
+func TestReconcile_GCDeletesReplicaWhoseOwnershipLabelWasStripped(t *testing.T) {
+	const cluster = "ownership-gc-spoke"
+	f := newFixture(t, "hunter2", []r8rv1alpha1.ResolvedTarget{{ClusterName: cluster}}, cluster)
+	f.policy(nil, nil)
+	f.reconcile()
+	f.drainEvents()
+	before := ownershipLostCount(t, cluster, telemetry.OwnershipDeleted)
+
+	stripManagedBy(t, f, cluster)
+	deselectAllTargets(t, f)
+	_, rep := f.reconcile()
+
+	if f.replica(cluster, f.ns) != nil {
+		t.Fatal("relabelled replica survived garbage collection")
+	}
+	if len(rep.Status.Inventory) != 0 {
+		t.Errorf("inventory = %+v, want empty", rep.Status.Inventory)
+	}
+	if got := ownershipLostCount(t, cluster, telemetry.OwnershipDeleted); got != before+1 {
+		t.Errorf("ownership deletions = %v, want %v", got, before+1)
+	}
+	if !eventsContaining(f.drainEvents(), ReasonOwnershipStripped) {
+		t.Error("deleting a relabelled replica was not reported")
+	}
+}
+
+// The same on the finalizer path: deleting the Replication must not leave a
+// relabelled replica behind on the spoke.
+func TestReconcile_DeletionCleansRelabelledReplica(t *testing.T) {
+	const cluster = "ownership-finalizer-spoke"
+	f := newFixture(t, "hunter2", []r8rv1alpha1.ResolvedTarget{{ClusterName: cluster}}, cluster)
+	f.policy(nil, nil)
+	f.reconcile()
+
+	stripManagedBy(t, f, cluster)
+
+	fresh := &r8rv1alpha1.Replication{}
+	if err := hubClient.Get(testCtx, client.ObjectKey{Namespace: f.ns, Name: "rep"}, fresh); err != nil {
+		t.Fatal(err)
+	}
+	if err := hubClient.Delete(testCtx, fresh); err != nil {
+		t.Fatal(err)
+	}
+
+	_, rep := f.reconcile()
+	if rep != nil {
+		t.Fatalf("replication still held by the finalizer: %+v", rep.Status.Inventory)
+	}
+	if f.replica(cluster, f.ns) != nil {
+		t.Fatal("relabelled replica stranded on the spoke after Replication deletion")
+	}
+}
+
+// An inventory entry pointing at an object the engine cannot recognise is
+// still not deleted — but it is no longer dropped in silence, which is what
+// "no code path may lose track of a created replica" requires.
+func TestReconcile_GCReleasesForeignObjectWithASignal(t *testing.T) {
+	const cluster = "ownership-orphan-spoke"
+	f := newFixture(t, "hunter2", []r8rv1alpha1.ResolvedTarget{{ClusterName: cluster}}, cluster)
+	f.policy(nil, nil)
+	f.reconcile()
+	f.drainEvents()
+	before := ownershipLostCount(t, cluster, telemetry.OwnershipOrphaned)
+
+	putForeignObject(f, cluster)
+	deselectAllTargets(t, f)
+	_, rep := f.reconcile()
+
+	if f.replica(cluster, f.ns) == nil {
+		t.Fatal("a foreign object was deleted by garbage collection")
+	}
+	if len(rep.Status.Inventory) != 0 {
+		t.Errorf("inventory = %+v, want the entry released", rep.Status.Inventory)
+	}
+	if got := ownershipLostCount(t, cluster, telemetry.OwnershipOrphaned); got != before+1 {
+		t.Errorf("orphan releases = %v, want %v", got, before+1)
+	}
+
+	var msg string
+	for _, e := range f.drainEvents() {
+		if strings.Contains(e, ReasonReplicaOrphaned) {
+			msg = e
+		}
+	}
+	if msg == "" {
+		t.Fatal("releasing an unrecognisable inventory entry produced no event")
+	}
+	if !strings.Contains(msg, "Warning") {
+		t.Errorf("%s is not a Warning: %q", ReasonReplicaOrphaned, msg)
+	}
+	if !strings.Contains(msg, replicaRef(cluster, f.ns, "web-creds")) {
+		t.Errorf("event does not name the replica: %q", msg)
+	}
+	if !strings.Contains(msg, "manual cleanup") {
+		t.Errorf("event does not say manual cleanup may be needed: %q", msg)
+	}
+}

--- a/internal/engine/reconciler.go
+++ b/internal/engine/reconciler.go
@@ -589,6 +589,43 @@ func (r *Reconciler) applyTarget(
 		}
 	case err != nil:
 		return fail(classifyTransportErr(err), err.Error(), true)
+	case ClassifyReplicaOwnership(existing.GetLabels(), src.GetUID()) == OwnershipStripped:
+		// The object still carries this replication's r8r.io/source-uid at
+		// the name our own inventory records, so it is our replica — but
+		// something rewrote or removed app.kubernetes.io/managed-by, which
+		// is the spoke cache's label selector. The replica had therefore
+		// dropped out of the drift watch entirely and no informer event
+		// would ever have surfaced it again (issue #36); this live read is
+		// what found it.
+		//
+		// Without this case it lands in DecideConflict's "unmanaged object"
+		// branch, which under the default Fail policy reports a Conflict
+		// AND removes the inventory entry — the engine forgetting a replica
+		// it created, which is how a copy of a Secret gets stranded on a
+		// spoke with nothing tracking it.
+		//
+		// Re-applying restores the ownership marks, which puts the object
+		// back inside the cache's selector: the repair IS the fix for the
+		// blindness, so the DriftDetector needs no notification.
+		observed := SourceHash(existing)
+		if applyErr := r.applyWithRecreate(ctx, s.cluster, desired); applyErr != nil {
+			return fail(classifyTransportErr(applyErr), applyErr.Error(), true)
+		}
+		telemetry.IncOwnershipLost(s.cluster, telemetry.OwnershipRepaired)
+		r.event(rep, "Warning", ReasonOwnershipRepaired, fmt.Sprintf(
+			"replica %s lost its %s label and had dropped out of the drift watch; ownership marks and content restored",
+			replicaRef(s.cluster, s.namespace, s.name), LabelManagedBy))
+		// A stripped label is metadata, not payload, so it must not move the
+		// drift-correction counter on its own (that counter's contract is
+		// "content was actually wrong"). When the payload diverged too, both
+		// signals fire — the pair is the strongest tampering evidence there
+		// is. Hashes only, never the diverging content.
+		if observed != hash {
+			telemetry.IncDriftCorrection(s.cluster)
+			r.event(rep, "Warning", "DriftCorrected",
+				fmt.Sprintf("restored replica %s: observed content %s, expected %s",
+					replicaRef(s.cluster, s.namespace, s.name), observed, hash))
+		}
 	default:
 		decision := DecideConflict(existing, src, hash, eff.AllowedConflictPolicies)
 		switch decision.Action {
@@ -763,10 +800,33 @@ func (r *Reconciler) collectGarbage(
 			})
 			delays = append(delays, r.backoff.Failure(nn, e.ClusterName))
 			continue
-		case !IsManagedReplica(existing.GetLabels(), rep.Spec.SourceRef.UID):
-			// Not ours — never touch it; just drop the entry.
-			*inv = removeEntry(*inv, KeyForEntry(e))
-			continue
+		default:
+			switch ClassifyReplicaOwnership(existing.GetLabels(), rep.Spec.SourceRef.UID) {
+			case OwnershipForeign:
+				// The object carries none of this replication's marks, so it
+				// is not ours to delete — the gate holds. What used to
+				// follow was a bare `continue`: the entry vanished with no
+				// event and no metric, which is precisely the "no code path
+				// may lose track of a created replica" the spec forbids.
+				// Refuse the delete, but say so.
+				telemetry.IncOwnershipLost(e.ClusterName, telemetry.OwnershipOrphaned)
+				r.event(rep, "Warning", ReasonReplicaOrphaned, fmt.Sprintf(
+					"inventory entry %s no longer carries this replication's ownership labels; releasing it without deleting anything — the object on the spoke may need manual cleanup",
+					replicaRef(e.ClusterName, e.Namespace, e.Name)))
+				*inv = removeEntry(*inv, KeyForEntry(e))
+				continue
+			case OwnershipStripped:
+				// managed-by was rewritten, but r8r.io/source-uid still
+				// names this replication's source: our replica, evicted from
+				// the drift watch. Cleanup is exactly the removal of what
+				// the engine created, so it is deleted below — abandoning it
+				// would strand a copy of the source on the spoke.
+				telemetry.IncOwnershipLost(e.ClusterName, telemetry.OwnershipDeleted)
+				r.event(rep, "Warning", ReasonOwnershipStripped, fmt.Sprintf(
+					"replica %s had lost its %s label; deleting it during cleanup anyway, because its %s label still identifies it",
+					replicaRef(e.ClusterName, e.Namespace, e.Name), LabelManagedBy, LabelSourceUID))
+			case OwnershipManaged:
+			}
 		}
 
 		err := r.Transport.Delete(ctx, e.ClusterName, obj)

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -102,6 +102,19 @@ var (
 		Help: "Replicas whose diverged content the engine rewrote to match the source (payload hash mismatch, not informer traffic), labeled by target cluster.",
 	}, []string{labelCluster})
 
+	// replicaOwnershipLost counts inventoried replicas found WITHOUT the
+	// `app.kubernetes.io/managed-by: k8s-r8r` label — the spoke cache's
+	// membership predicate, so such a replica had dropped out of the drift
+	// watch entirely (issue #36). Distinct from driftCorrections: a rewritten
+	// ownership label is not payload divergence, and conflating the two would
+	// break the guarantee that a non-zero drift-correction count always means
+	// a replica's content was actually wrong. When a replica lost its label
+	// AND its content diverged, both counters move.
+	replicaOwnershipLost = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "k8s_r8r_replica_ownership_lost_total",
+		Help: "Inventoried replicas found without the k8s-r8r managed-by label (and therefore outside the drift watch), labeled by target cluster and by how the engine resolved it (repaired, deleted, orphaned).",
+	}, []string{labelCluster, labelAction})
+
 	// spokeBootstraps counts spoke bootstrap attempts by result.
 	spokeBootstraps = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "k8s_r8r_spoke_bootstraps_total",
@@ -134,6 +147,28 @@ func IncDriftEvent(cluster string) { driftEvents.WithLabelValues(cluster).Inc() 
 // rewrote on a target cluster. Call it only for real payload divergence, not
 // for repairs of the engine's own bookkeeping annotation.
 func IncDriftCorrection(cluster string) { driftCorrections.WithLabelValues(cluster).Inc() }
+
+// Resolutions of an inventoried replica found outside the drift watch. A
+// closed enumeration: these are the only values IncOwnershipLost accepts.
+const (
+	// OwnershipRepaired: the replica's marks were restored, which also
+	// returns it to the watch's label selector.
+	OwnershipRepaired = "repaired"
+	// OwnershipDeleted: the replica was garbage-collected despite the
+	// rewritten label, because its source-uid still identified it.
+	OwnershipDeleted = "deleted"
+	// OwnershipOrphaned: the object at the inventoried name was foreign, so
+	// the entry was released without deleting anything. The only resolution
+	// that implies manual work — alert on this one.
+	OwnershipOrphaned = "orphaned"
+)
+
+// IncOwnershipLost records one inventoried replica found without the
+// managed-by label, by how the engine resolved it (OwnershipRepaired,
+// OwnershipDeleted, OwnershipOrphaned).
+func IncOwnershipLost(cluster, action string) {
+	replicaOwnershipLost.WithLabelValues(cluster, action).Inc()
+}
 
 // IncSpokeBootstrap records one spoke bootstrap attempt.
 func IncSpokeBootstrap(success bool) { spokeBootstraps.WithLabelValues(resultLabel(success)).Inc() }
@@ -387,6 +422,7 @@ func init() {
 		revocations,
 		driftEvents,
 		driftCorrections,
+		replicaOwnershipLost,
 		spokeBootstraps,
 		tokenRotations,
 		replicas,

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -35,6 +35,9 @@ func exerciseAll() {
 	IncRevocation("delete")
 	IncDriftEvent("spoke-a")
 	IncDriftCorrection("spoke-a")
+	IncOwnershipLost("spoke-a", OwnershipRepaired)
+	IncOwnershipLost("spoke-a", OwnershipDeleted)
+	IncOwnershipLost("spoke-a", OwnershipOrphaned)
 	IncSpokeBootstrap(true)
 	IncSpokeBootstrap(false)
 	IncTokenRotation(true)
@@ -114,6 +117,7 @@ func TestMetricInventoryComplete(t *testing.T) {
 		"k8s_r8r_revocations_total",
 		"k8s_r8r_drift_events_total",
 		"k8s_r8r_drift_corrections_total",
+		"k8s_r8r_replica_ownership_lost_total",
 		"k8s_r8r_cluster_connectivity",
 		"k8s_r8r_clusters",
 		"k8s_r8r_discovery_up",

--- a/openspec/changes/verify-replica-ownership/.openspec.yaml
+++ b/openspec/changes/verify-replica-ownership/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/verify-replica-ownership/design.md
+++ b/openspec/changes/verify-replica-ownership/design.md
@@ -1,0 +1,308 @@
+# Design: Verify replica ownership
+
+## Context
+
+Issue #36 proposes two complementary shapes:
+
+1. reconcile-time verification of inventory members via `Transport.Get`,
+   independent of the informer;
+2. a signal when an inventory member is not found in the filtered cache after
+   a resync.
+
+Reading the engine changes the shape of both.
+
+**Shape (1) already exists — it is just misinterpreted.** `applyTarget`
+already performs a live `Transport.Get` for every allowed slot on every
+reconcile, and `collectGarbage` performs one for every entry it is about to
+delete. Between them they cover every inventory entry except revoked-retained
+ones (D5). What is missing is not the read; it is that the *result* of the
+read is classified with a predicate that cannot express "this is our replica,
+relabelled":
+
+```go
+// DecideConflict
+if IsManagedReplica(labels, src.GetUID()) { return ConflictDecision{Action: ActionApply} }
+if labels[LabelManagedBy] == ManagedByValue { /* different source → Fail */ }
+// → falls through to "unmanaged object", conflict policy decides
+```
+
+`IsManagedReplica` requires *both* `app.kubernetes.io/managed-by: k8s-r8r`
+*and* a matching `r8r.io/source-uid`. Strip only the first and the engine's
+own replica lands in the unmanaged branch. With the default effective conflict
+policy of `Fail` that produces `ActionFail`, and `fail(..., retry=false)`
+removes the inventory entry — the engine forgets a replica it created.
+
+So the actual behaviour today is not "nothing happens". It is:
+
+| when | today |
+|---|---|
+| watch | permanently blind to the replica (it is outside the label selector) |
+| next periodic reconcile (`--spoke-resync`, default 10h) | live read succeeds, object misclassified as a foreign conflict, `Conflict` condition, **inventory entry dropped** |
+| following reconcile | entry re-planned, dropped again — an oscillation, and one `Conflict` event per cooldown window |
+| `Replication` deleted meanwhile | the replica is only cleaned up if the deletion catches a cycle where the entry exists; otherwise it is stranded |
+| GC of a deselected target | safety gate sees a non-replica, drops the entry **silently** — replica stranded, no event, no metric |
+
+Detection latency degrading from seconds to `--spoke-resync` is the reported
+bug. The dropped inventory entry and the silent GC release are worse, because
+they strand a copy of the replicated Secret with nothing tracking it.
+
+**Shape (2) does not need cache probing.** "Not in the filtered cache" and
+"does not carry `managed-by: k8s-r8r`" are the same statement — the label *is*
+the selector. Deriving the signal from the live read is therefore strictly
+better than asking the informer: it is authoritative rather than
+eventually-consistent, it cannot false-positive on cache lag or on an informer
+that has not synced yet, and it needs no new plumbing from `DriftDetector`
+into the reconciler. Shape (2) is implemented as a classification of the read
+that shape (1) already performs.
+
+## Decisions
+
+### D1: Three-state ownership, keyed on the provenance label
+
+```go
+type ReplicaOwnership int
+const (
+    OwnershipForeign  ReplicaOwnership = iota // neither mark
+    OwnershipManaged                          // managed-by + matching source-uid
+    OwnershipStripped                         // source-uid matches, managed-by does not
+)
+```
+
+`r8r.io/source-uid` carries the hub source object's UID. Nothing but this
+engine writes it, and a UID is not guessable or reusable — a Secret deleted
+and recreated under the same name gets a different UID, and the request
+controller then treats it as a different source. An object carrying our
+source's UID at the exact name our inventory records is our replica, whatever
+happened to its `managed-by` label.
+
+The two labels are not interchangeable: `managed-by` is a *conventional*
+label that third-party tooling legitimately writes (it is
+`app.kubernetes.io/`-namespaced and half the ecosystem stamps it), while
+`source-uid` is `r8r.io/`-namespaced and specific. That asymmetry is the whole
+reason the failure exists, and it is what makes `source-uid` the right thing
+to key recovery on.
+
+`IsManagedReplica` is left exactly as it is. It is the GC safety gate and the
+conflict predicate; weakening it would weaken both. The new classification is
+additive.
+
+**Rejected: widening the cache selector.** That is design D3's ("the hub must
+never cache replica payloads") memory bound across a fleet, and it would trade
+a correctness bug for an unbounded one.
+
+**Rejected: gating repair on the inventory entry's `LastAppliedHash`.** A
+recorded hash proves the engine applied the object, which looks like a useful
+second key. It is a trap: the pre-fix code path *removes* the entry on
+conflict-`Fail`, so after a single bad cycle on an old operator the hash is
+gone and the entry is re-planned empty — an upgrade from an affected version
+would find the repair permanently disabled on exactly the replicas that need
+it. The source-UID label alone is the durable evidence.
+
+### D2: `Stripped` is repaired, not conflicted
+
+A new case in `applyTarget`'s existing switch, ahead of `DecideConflict`:
+
+```go
+case ClassifyReplicaOwnership(existing.GetLabels(), src.GetUID()) == OwnershipStripped:
+    // re-apply; the ownership marks come back with it
+```
+
+The re-apply is a plain `applyWithRecreate` of the rendered desired object,
+identical to the drift-repair write. Its important second effect is that
+**restoring `managed-by` puts the object back inside the spoke cache's label
+selector, so the informer starts delivering events for it again.** The repair
+is not merely a workaround for the blindness — it ends it. Nothing else needs
+to notify the `DriftDetector`.
+
+Is re-applying a form of stealing? No, and the boundary is worth stating:
+this is not the conflict path and it is not `Overwrite`. It applies only to
+an object that carries this replication's own source UID at a name its own
+inventory records. A controller that genuinely wants to own the object has to
+remove `r8r.io/source-uid` too — at which point the object is `Foreign`, the
+existing conflict machinery handles it, the two-key conflict contract (#34)
+applies unchanged, and the engine will not touch it under the default policy.
+
+**Ready is truthful afterwards.** Post-repair the replica matches the source
+and carries correct marks, so `Ready=True` for that target is a true
+statement, not the false one the issue describes.
+
+### D3: Cost at fleet scale — no additional reads on the healthy path
+
+The instruction was to think about 50 clusters × 500 replicas and say so
+explicitly.
+
+Take the whole inventory of a hub, and ask which entries are read live today:
+
+| entry class | live `Get` today | by |
+|---|---|---|
+| desired + policy-allowed | yes, every reconcile | `applyTarget` |
+| not kept (deselected, renamed, revoked-`Delete`, Replication deleting) | yes, before deleting | `collectGarbage` safety gate |
+| revoked + retained | **no** | — (D5) |
+
+Every entry except the retained ones is already read. This change adds a
+label comparison to reads that already happen. **The steady-state API cost of
+the fix is zero additional requests.**
+
+The absolute numbers, for the record. 50 clusters × 500 replicas = 25,000
+inventory entries. A healthy `Replication` requeues after
+`Options.DriftResync` (`--spoke-resync`, default 10h), so the existing
+verification sweep is already ~25,000 spoke `GET`s per 10h ≈ **0.7 requests
+per second across the whole fleet**, ~0.014 rps per spoke API server. That is
+noise next to a kubelet. It is also unchanged by this proposal — worth
+stating precisely because the obvious implementation of "verify every
+inventory member on every reconcile" would have *introduced* that load, and
+it turns out not to be needed.
+
+Extra cost only appears where something is actually wrong: one additional
+apply per stripped replica, bounded by the number of tampered replicas, not
+by fleet size. Metric cardinality grows by one family × clusters × 3 bounded
+action values.
+
+The one number that does move is the **hub-side** reconcile: nothing, because
+classification is a map lookup on labels already in memory.
+
+### D4: Detection latency stays bounded by `--spoke-resync`
+
+Worst-case time to notice a stripped label is one resync interval — 10h by
+default — because the watch cannot see the object and the periodic reconcile
+is what finds it.
+
+A dedicated, shorter ownership-verification interval was considered and
+rejected:
+
+- it needs a new flag in `cmd/main.go`, a file another change owns this
+  sprint, and a flag is a permanent API for a transient problem;
+- the repair is self-healing: once an object is repaired it is back in the
+  watch, so the slow path is traversed once per tampering event, not
+  continuously;
+- operators who need a tighter bound already have the knob. `--spoke-resync`
+  lowers both the informer resync and the periodic reconcile together, which
+  is the correct coupling — they are the same fallback.
+
+This is stated in `docs/security.md` so the window is a documented property
+rather than a surprise.
+
+### D5: Revoked-but-retained entries are deliberately not verified
+
+`revocationPolicy: Retain` entries sit in `keep` but are never applied and
+never collected, so they are the one class of inventory entry with no live
+read. Adding one would be cheap. It is still wrong:
+
+the engine's promise for a retained replica is *"retained but no longer
+updated"* — the target's own condition message says so. Repairing its
+ownership marks would be a write to an object the engine has explicitly
+stopped writing to, and would silently re-arm drift correction on material
+that policy no longer permits it to manage.
+
+So retained replicas are outside ownership verification by the same rule that
+puts them outside drift repair. This is a documented boundary, not an
+oversight: `docs/security.md` states that a retained replica is released from
+the engine's control, and that deleting it is the operator's call.
+
+### D6: A separate signal from drift correction — and both when both apply
+
+`k8s_r8r_drift_corrections_total` carries an invariant established by #30 and
+written into its help string: *a non-zero value always means a replica's
+payload was actually wrong*. A stripped `managed-by` label over byte-identical
+content is not a payload problem, so counting it there would break that
+invariant for the same reason the annotation-only repair is excluded.
+
+Hence a separate family:
+
+```
+k8s_r8r_replica_ownership_lost_total{cluster, action}
+```
+
+with `action` ∈ `repaired` | `deleted` | `orphaned`. `cluster` and `action`
+are both already on the metrics allowlist; the replica's namespace and name
+are unbounded and belong in the event, which carries them in full.
+
+The three actions answer different operator questions and must not be one
+counter:
+
+- `repaired` — a replica was outside the watch and has been put back. Ongoing
+  increments mean something on that spoke keeps taking the label, i.e. a
+  controller fight.
+- `deleted` — a stripped replica was garbage-collected. Confirms cleanup
+  worked *despite* the tampering; a silent gap here is what strands secrets.
+- `orphaned` — an object at an inventoried name is unrecognisable, so the
+  entry was released without deleting anything. **This is the only action
+  that implies manual work**, and it needs to be alertable on its own.
+
+**Both signals fire when both conditions hold.** A replica that lost its label
+*and* had its payload rewritten increments `replica_ownership_lost{repaired}`
+*and* `drift_corrections`, and emits both events. That composition is the
+point: the counters stay independently meaningful, and the pair "ownership
+repaired + drift corrected on the same replica" is the strongest tampering
+signature the operator can get.
+
+### D7: The silent GC release becomes an event
+
+`collectGarbage`'s gate is correct in refusing to delete an object it cannot
+recognise — a planned-but-never-applied entry must never delete a bystander.
+Its bug is the `continue` that follows: the entry disappears with no output.
+
+The spec already forbids this. *Inventory and garbage collection* ends with
+"No code path may lose track of a created replica", and this path does
+exactly that. The fix keeps the refusal and adds the report:
+
+- `OwnershipStripped` → proceed to delete (it is ours; `source-uid` says so),
+  count `deleted`;
+- `OwnershipForeign` → release the entry, count `orphaned`, and emit a
+  `Warning` `ReplicaOrphaned` naming the replica and saying the object on the
+  spoke may need manual cleanup.
+
+Deleting a stripped replica during GC deserves its own justification, because
+it is a delete the old code would not have performed. It is the same object
+this `Replication` created, at the name it recorded, carrying its source UID;
+GC is precisely the removal of what the engine created. Not deleting it is
+the worse outcome — it leaves a copy of a Secret on a spoke with the tracking
+entry gone. And the case where the object is genuinely somebody else's now
+(both marks rewritten) is `Foreign`, which is still never deleted.
+
+**No status change.** Neither path adds a `targetState`: a released orphan is
+not a desired slot, and inventing a slot state for it would put a
+non-target into `status.targets`. The `ClusterGone` release precedent — event
+only, no state — is followed exactly.
+
+### D8: Message contents
+
+```
+replica <cluster>/<ns>/<name> lost its app.kubernetes.io/managed-by label and had dropped
+out of the drift watch; ownership marks and content restored
+
+inventory entry <cluster>/<ns>/<name> no longer carries this replication's ownership
+labels; releasing it without deleting anything — the object on the spoke may need manual
+cleanup
+```
+
+Built from `replicaRef()` and label-name constants. No payload term appears,
+which keeps both clear of the AST ratchet in
+`internal/telemetry/secretsafety_audit_test.go` (`Data` / `StringData` /
+`BinaryData` selectors and string-index keys are banned inside `event` /
+`Eventf` / `Sprintf` arguments). Naming the label explicitly is deliberate:
+the operator's next action is to find what is writing it.
+
+`Warning` for both. Something outside the operator changed ownership metadata
+on replicated material; that belongs in the stream an operator filters for.
+
+## Risks / Trade-offs
+
+- **A GitOps tool that owns `app.kubernetes.io/managed-by` fleet-wide** now
+  gets its label overwritten on every reconcile instead of a `Conflict`, and
+  the two controllers will fight — visibly, at ~1 write per `--spoke-resync`
+  per replica plus one `repaired` increment. That is louder than today's
+  silence and much louder than today's stranded secret, and the escape hatch
+  is real: the tool should not target objects labelled `r8r.io/source-uid`,
+  or the replica should not be replicated there.
+- **Existing fleets will report ownership losses that were previously
+  invisible.** Same shape as #30's rollout: a fleet with pre-existing damage
+  looks like a new problem on upgrade. It is not new — it was simply
+  unobservable.
+- **10h default detection window** for the eviction itself (D4). Bounded and
+  documented, and reduced by lowering `--spoke-resync`.
+- **A stripped replica is now deleted at GC time** where it used to be
+  abandoned (D7). This is a behaviour change in the deleting direction, so it
+  is called out in the CHANGELOG. It only ever applies to an object carrying
+  this replication's own source UID.
+- **Retained replicas stay unverified** (D5) — accepted, documented.

--- a/openspec/changes/verify-replica-ownership/proposal.md
+++ b/openspec/changes/verify-replica-ownership/proposal.md
@@ -1,0 +1,125 @@
+# Verify replica ownership
+
+## Why
+
+The spoke caches are built with a server-side label selector on
+`app.kubernetes.io/managed-by: k8s-r8r` (`cmd/main.go`, cache options), and
+`driftHandler.observe` (`internal/engine/drift.go`) filters on the same label
+again. That label is therefore not merely an annotation on a replica — it is
+the **membership predicate of the drift watch**.
+
+Anything on a spoke that rewrites or removes it — a second controller
+claiming the object, a GitOps tool stamping its own ownership labels, an
+operator tidying labels by hand — silently evicts the replica from the watch
+while it stays in the `Replication`'s inventory (issue #36).
+
+The existing drift requirements never state this dependency. "A hash mismatch
+or replica deletion observed via watch SHALL enqueue the affected
+`(source, targetCluster)`" **implicitly assumes the watch sees every
+inventoried replica**, and that assumption is exactly what a rewritten
+`managed-by` label breaks. This change makes the assumption explicit and gives
+the engine a path that does not depend on it.
+
+Tracing what actually happens today turned up two concrete defects behind the
+reported one, both worse than lost watch coverage:
+
+1. **`applyTarget` drops the inventory entry for a replica it created.**
+   The next periodic reconcile does read the object live
+   (`Transport.Get`), but `DecideConflict` sees no `managed-by` label,
+   classifies the engine's own replica as an *unmanaged foreign object*, and
+   returns `ActionFail`. `fail(..., retry=false)` then calls
+   `removeEntry` — the engine forgets a replica it wrote. The entry is
+   re-planned on the next pass and dropped again, so the `Replication`
+   oscillates, and a deletion landing in the wrong half of that cycle leaves
+   the replica behind forever. For a Secret replicator that is a copy of
+   credential material stranded on a spoke with nothing tracking it.
+
+2. **`collectGarbage` releases such an entry silently.** Its safety gate
+   (`!IsManagedReplica(...)` → "not ours, just drop the entry") cannot tell
+   *"we never created this"* from *"we created this and someone relabelled
+   it"*. Both are dropped, with no event and no metric. The gate is right to
+   refuse to delete a foreign object; it is wrong to say nothing.
+
+Severity is **security-relevant**: the failure mode is a replicated Secret
+that the engine no longer watches, no longer tracks, and will not clean up,
+while `Ready=True` and the inventory both keep looking healthy.
+
+## What Changes
+
+- **Ownership is classified, not just tested.** A new
+  `ClassifyReplicaOwnership` distinguishes three states of an object found at
+  an inventoried replica's name: `Managed` (both marks), `Stripped` (the
+  `r8r.io/source-uid` provenance label still matches this source but
+  `managed-by` was rewritten or removed — provably our replica, evicted from
+  the watch), and `Foreign` (neither mark).
+- **`applyTarget` repairs the `Stripped` state** instead of misfiling it as a
+  conflict: it re-applies, which restores the ownership marks and thereby
+  **puts the object back into the filtered cache — the repair is the fix for
+  the blindness**. The inventory entry survives.
+- **`collectGarbage` deletes a `Stripped` replica** rather than abandoning
+  it: a stripped label does not stop it being a copy of the source that this
+  `Replication` created and is responsible for removing. `Foreign` objects
+  are still never touched, but their release is now **reported** instead of
+  silent.
+- **New metric `k8s_r8r_replica_ownership_lost_total{cluster, action}`**,
+  `action` ∈ `repaired` | `deleted` | `orphaned` — one increment per
+  inventoried replica found without the watch's membership label, labelled by
+  how the engine resolved it.
+- **New `Warning` events** `OwnershipRepaired` and `ReplicaOrphaned` on the
+  `Replication`, naming the replica and the label. Hashes only, never
+  payload.
+- **Content divergence still reports as drift.** A replica that lost its
+  label *and* had its payload rewritten emits both signals and increments
+  both counters, preserving the invariant from #30 that a non-zero
+  `k8s_r8r_drift_corrections_total` always means a payload was actually
+  wrong.
+- **No new flag, no new API call on the healthy path.** Verification reuses
+  the live reads the reconcile already performs. See design D3 for the cost
+  analysis at fleet scale.
+- Deliberately **out of scope**: verifying revoked-but-retained inventory
+  entries (design D5), and shortening the verification interval below
+  `--spoke-resync` (design D4).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `replication-engine`: gains a *Replica ownership verification* requirement
+  stating that the drift watch's membership label is not trusted as the only
+  evidence of ownership, and that a stripped label is repaired rather than
+  reclassified as a conflict. *Inventory and garbage collection* gains the
+  rule that an inventory entry is never released without either deleting the
+  replica or reporting the release — the current silent drop violates its own
+  "no code path may lose track of a created replica".
+- `observability-operations`: gains a *Replica ownership signals* requirement
+  for the new metric and events.
+
+The metric enumeration in *Prometheus metrics* and the event enumeration in
+*Rate-limited structured events* are the natural home for the new signals,
+but both are already modified by the unarchived `report-drift-corrections`
+change. Restating them here would make whichever change syncs second silently
+discard the other's text, so the ownership signals are stated as their own
+requirement; folding them into the two enumerations belongs to the archive
+pass for this sprint.
+
+## Impact
+
+- `internal/engine/drift.go` — `ReplicaOwnership`, `ClassifyReplicaOwnership`,
+  and the doc comment tying the label to cache membership.
+- `internal/engine/reconciler.go` — one new case in `applyTarget`'s existing
+  switch; the `collectGarbage` safety gate.
+- `internal/telemetry/metrics.go` — `replicaOwnershipLost` counter,
+  `IncOwnershipLost(cluster, action)`, registration.
+- `internal/telemetry/metrics_test.go` — the new family joins the inventory
+  and cardinality audits.
+- `internal/engine/ownership_test.go` (new) — classification unit table,
+  repair, repair + content drift, foreign object unchanged, GC of a stripped
+  replica, reported release of a foreign one.
+- `docs/security.md` — the ownership label as a watch-membership predicate,
+  the new signals, and the retained-replica exception.
+- `CHANGELOG.md` — entry under Unreleased.
+- No CRD, no chart, no RBAC, no flag, no `Replication` API change.

--- a/openspec/changes/verify-replica-ownership/specs/observability-operations/spec.md
+++ b/openspec/changes/verify-replica-ownership/specs/observability-operations/spec.md
@@ -1,0 +1,20 @@
+# observability-operations
+
+## ADDED Requirements
+
+### Requirement: Replica ownership signals
+Loss of a replica's ownership marks SHALL be observable, because it removes the replica from the drift watch's label selector and therefore from every watch-derived signal.
+
+The operator SHALL expose a counter of inventoried replicas found without the `app.kubernetes.io/managed-by: k8s-r8r` label, labeled by target cluster and by how the engine resolved the finding: the replica's marks were restored, the replica was deleted during garbage collection, or the inventory entry was released without deleting anything because the object at that name was foreign. The label set SHALL remain bounded — the cluster name and a closed enumeration of resolutions; the replica's namespace and name belong in the event.
+
+This counter SHALL be distinct from the drift-correction counter. A rewritten ownership label is not payload divergence, and conflating the two would break the drift-correction counter's guarantee that a non-zero value always means a replica's content was actually wrong. When a replica has both lost its ownership marks and had its content rewritten, both counters SHALL be incremented.
+
+The operator SHALL emit a `Warning` event on the `Replication` for each resolution: one naming the repaired replica and the label that was rewritten, and one naming a released inventory entry and stating that the object on the spoke may require manual cleanup. Both events SHALL identify the replica by cluster, namespace and name only, and SHALL NOT contain payload.
+
+#### Scenario: Ownership label rewritten on a spoke
+- **WHEN** something on a spoke rewrites a replica's managed-by label and the engine restores it on the next reconcile
+- **THEN** the ownership counter increments for that cluster with the repaired resolution, a `Warning` event names the replica and the label, and the drift-correction counter does not move because no content had diverged
+
+#### Scenario: Inventory entry released without deletion
+- **WHEN** the object at an inventoried replica's name is foreign and the engine releases the entry without deleting it
+- **THEN** the ownership counter increments with the released resolution and a `Warning` event states that manual cleanup may be needed, so the released replica is not merely absent from the inventory

--- a/openspec/changes/verify-replica-ownership/specs/replication-engine/spec.md
+++ b/openspec/changes/verify-replica-ownership/specs/replication-engine/spec.md
@@ -1,0 +1,61 @@
+# replication-engine
+
+## ADDED Requirements
+
+### Requirement: Replica ownership verification
+The `app.kubernetes.io/managed-by: k8s-r8r` label is the membership predicate of the spoke drift watch: an inventoried replica that loses it is invisible to the watch, so drift detection SHALL NOT depend on that label alone as evidence of ownership.
+
+The engine SHALL classify an object found at an inventoried replica's name by both of its ownership marks and SHALL distinguish three states: the object carries the managed-by label and this replication's `r8r.io/source-uid` (managed); the object carries a matching `r8r.io/source-uid` but not the managed-by label (ownership stripped); the object carries neither (foreign).
+
+An object whose ownership is stripped SHALL be treated as this replication's replica and SHALL NOT be classified as a conflict with a foreign object. The engine SHALL restore its ownership marks and content, SHALL retain its inventory entry, and SHALL report the repair. Restoring the managed-by label returns the object to the watch's label selector, so a repaired replica SHALL again be observable by the drift watch without further action.
+
+A foreign object SHALL NOT be repaired or taken over by ownership verification; it remains subject to the conflict-handling requirement and its two-key consent contract.
+
+Verification SHALL be performed with live reads independent of the informer, and SHALL NOT require reads beyond those the reconcile already performs for its desired slots and its garbage-collection candidates. Revoked replicas retained under `revocationPolicy: Retain` are excluded from verification, because the engine has undertaken not to write to them.
+
+The worst-case time to detect a stripped ownership label is one resync interval, since the watch cannot deliver events for an object outside its selector.
+
+#### Scenario: Ownership label rewritten on a replica
+- **WHEN** something on a spoke rewrites or removes `app.kubernetes.io/managed-by` on a replica while its `r8r.io/source-uid` still identifies this replication's source
+- **THEN** the next reconcile restores the replica's ownership marks and content, keeps its inventory entry, reports the repair as an event and a metric increment, and the replica is delivered by the drift watch again
+
+#### Scenario: Ownership label rewritten and content edited
+- **WHEN** a replica has both lost its managed-by label and had its payload rewritten on the spoke
+- **THEN** the engine reports both an ownership repair and a drift correction, so neither signal is masked by the other
+
+#### Scenario: Foreign object at a replica's name
+- **WHEN** an object at an inventoried replica's name carries neither this replication's managed-by label nor its source-uid label
+- **THEN** ownership verification does not touch it and the conflict-handling requirement decides the outcome
+
+#### Scenario: Retained replica after revocation
+- **WHEN** a replica is retained under `revocationPolicy: Retain` and its ownership label is later rewritten
+- **THEN** the engine does not repair it, because a retained replica is no longer written to by the engine
+
+## MODIFIED Requirements
+
+### Requirement: Inventory and garbage collection
+The engine SHALL record every created replica in the `Replication` object's inventory and SHALL delete replicas (honoring `revocationPolicy` where applicable) when: the source is deleted (a finalizer on the source blocks its deletion until replica cleanup completes), the request annotations are removed, or a target leaves the resolved selection (cluster label change, selector change, namespace removed from the list). Cluster deregistration releases that cluster's inventory entries with a `ClusterGone` event without deleting replicas on the spoke — after deregistration the engine holds no credential for the cluster, so remote deletion is impossible; the clean removal path is deselecting the cluster (label/selector change) before deregistering it. No code path may lose track of a created replica.
+
+Before deleting, the engine SHALL verify that the object at an inventory entry's name is one it created, so that a planned-but-never-applied entry can never delete an object the engine does not manage. That verification SHALL use both ownership marks: an object whose managed-by label was rewritten but whose `r8r.io/source-uid` still matches this replication's source is still this replication's replica and SHALL be deleted.
+
+An inventory entry SHALL NOT be released silently. When the engine drops an entry without deleting the corresponding object — because the object at that name is foreign and must not be touched — it SHALL emit an event identifying the replica and stating that the object may require manual cleanup, and SHALL increment a metric for it, so that a replica the engine can no longer account for is observable rather than merely absent.
+
+#### Scenario: Source deletion cleans the fleet
+- **WHEN** a replicated Secret is deleted on the hub
+- **THEN** the finalizer defers deletion until all inventoried replicas are removed from reachable targets, then the source and its `Replication` object are released
+
+#### Scenario: Target leaves selection
+- **WHEN** a cluster's labels change so it no longer matches the request's cluster selector
+- **THEN** replicas on that cluster are deleted and removed from inventory
+
+#### Scenario: Unreachable target during cleanup
+- **WHEN** replicas must be cleaned from a cluster that is unreachable
+- **THEN** cleanup is retried with backoff, the condition is reported, and after the cluster is deregistered from discovery the inventory entries are released with a `ClusterGone` event rather than blocking forever
+
+#### Scenario: Cleanup of a replica whose ownership label was rewritten
+- **WHEN** an inventoried replica whose managed-by label was rewritten must be cleaned up
+- **THEN** it is deleted from the spoke, because its source-uid label still identifies it as this replication's replica, and the deletion is reported
+
+#### Scenario: Inventory entry pointing at a foreign object
+- **WHEN** the object at an inventory entry's name carries none of this replication's ownership marks
+- **THEN** the engine deletes nothing, releases the entry, and reports the release with an event and a metric rather than dropping the entry silently

--- a/openspec/changes/verify-replica-ownership/tasks.md
+++ b/openspec/changes/verify-replica-ownership/tasks.md
@@ -1,0 +1,84 @@
+# Tasks — verify replica ownership
+
+## 1. Ownership classification
+
+- [x] 1.1 Add `ReplicaOwnership` (`Foreign` / `Managed` / `Stripped`) and
+      `ClassifyReplicaOwnership(labels, sourceUID)` in
+      `internal/engine/drift.go`, with a doc comment stating that
+      `app.kubernetes.io/managed-by` is the spoke cache's membership
+      predicate, so `Stripped` means "invisible to the drift watch".
+- [x] 1.2 Leave `IsManagedReplica` unchanged — it is the GC safety gate and
+      the conflict predicate (design D1).
+
+## 2. Telemetry
+
+- [x] 2.1 Add the `replicaOwnershipLost` counter
+      (`k8s_r8r_replica_ownership_lost_total{cluster, action}`) with
+      `IncOwnershipLost(cluster, action)` and the three action constants
+      (`repaired`, `deleted`, `orphaned`); register it. Help string must say
+      what separates it from `k8s_r8r_drift_corrections_total`.
+
+## 3. Engine — repair on the apply path
+
+- [x] 3.1 New case in `applyTarget`'s existing switch, ahead of `default:`,
+      for `OwnershipStripped`: re-apply via `applyWithRecreate`, count
+      `repaired`, emit a `Warning` / `OwnershipRepaired` event naming the
+      replica and the label. Keep the inventory entry.
+- [x] 3.2 When the stripped replica's content had *also* diverged, additionally
+      emit `DriftCorrected` and increment `k8s_r8r_drift_corrections_total`,
+      preserving #30's invariant (design D6).
+- [x] 3.3 Note in a code comment that restoring the label puts the object back
+      inside the cache's label selector — the repair ends the blindness.
+
+## 4. Engine — reported release on the GC path
+
+- [x] 4.1 Replace `collectGarbage`'s `!IsManagedReplica` gate with the
+      three-state classification: `Stripped` falls through to the delete
+      (count `deleted`), `Foreign` releases the entry with a `Warning` /
+      `ReplicaOrphaned` event and counts `orphaned`.
+- [x] 4.2 No `targetState` for either path — event only, like the
+      `ClusterGone` release (design D7).
+
+## 5. Tests
+
+- [x] 5.1 `ClassifyReplicaOwnership` table: both marks, stripped label,
+      rewritten label, foreign object, empty labels, different source UID.
+- [x] 5.2 Stripped label at a desired slot: label restored, entry kept, one
+      `repaired` increment, one `OwnershipRepaired` Warning naming the replica
+      and the label, no `Conflict`.
+- [x] 5.3 Stripped label + diverged content: both events, both counters.
+- [x] 5.4 Foreign object at a desired slot still takes the conflict path
+      unchanged (regression guard for #34's two-key contract).
+- [x] 5.5 GC of a stripped replica actually deletes it from the spoke and
+      counts `deleted` (deselected target and Replication deletion).
+- [x] 5.6 GC of a foreign object at an inventoried name deletes nothing,
+      releases the entry, counts `orphaned`, and emits `ReplicaOrphaned`.
+- [x] 5.7 No payload appears in any new message (explicit leak assertions).
+- [x] 5.8 Telemetry: the new family joins `exerciseAll` and the inventory /
+      cardinality audits.
+- [x] 5.9 Confirm `TestNoPayloadFieldsInMessageFormatting` still passes.
+
+## 6. Docs
+
+- [x] 6.1 `docs/security.md`: the ownership label as the watch's membership
+      predicate, the failure it used to cause, the new signals table, the
+      `--spoke-resync` detection window, and the retained-replica exception.
+- [x] 6.2 `CHANGELOG.md`: entry under Unreleased, including the
+      behaviour change that a stripped replica is now deleted at GC time.
+- [ ] 6.3 `obsidian/` vault updates: owned by a parallel change in this
+      sprint; the required edits are listed in the PR body.
+
+## 7. Verification
+
+- [x] 7.1 `make lint && make test` — 290 tests green. Lint verified against a
+      pristine export of the tree (`golangci-lint run` from inside an agent
+      worktree also analyses sibling worktrees, which produces unrelated
+      `SA5011` noise from other agents' in-flight files); `origin/main` and
+      this branch both report 0 issues in isolation.
+- [ ] 7.2 `make test-e2e` — not run locally (no docker on this machine); the
+      CI `E2E (kind fleet, hub + 2 spokes)` job covers it. No e2e case was
+      added for the label-strip path on purpose: e2e runs with the default
+      10h `--spoke-resync`, and the eviction is invisible to the watch by
+      construction, so the case cannot be exercised there without a
+      resync-interval override. The existing "drift repair on replica
+      edit/delete" cases still cover the unchanged watch path.

--- a/openspec/changes/verify-replica-ownership/tasks.md
+++ b/openspec/changes/verify-replica-ownership/tasks.md
@@ -75,8 +75,9 @@
       worktree also analyses sibling worktrees, which produces unrelated
       `SA5011` noise from other agents' in-flight files); `origin/main` and
       this branch both report 0 issues in isolation.
-- [ ] 7.2 `make test-e2e` — not run locally (no docker on this machine); the
-      CI `E2E (kind fleet, hub + 2 spokes)` job covers it. No e2e case was
+- [x] 7.2 `make test-e2e` — not run locally (no docker on this machine), but
+      CI's `E2E (kind fleet, hub + 2 spokes)` job ran it on this branch and
+      passed (10m59s, run 33870175449). No e2e case was
       added for the label-strip path on purpose: e2e runs with the default
       10h `--spoke-resync`, and the eviction is invisible to the watch by
       construction, so the case cannot be exercised there without a


### PR DESCRIPTION
Fixes #36

## What was actually wrong

`app.kubernetes.io/managed-by: k8s-r8r` is not decoration on a replica — it is the **server-side label selector the spoke caches are built with** (`cmd/main.go`) and the filter `driftHandler.observe` applies again (`internal/engine/drift.go`). It is the membership predicate of the drift watch. Anything on a spoke that rewrites it evicts the replica from the informer permanently.

Tracing what happens after that eviction turned up two defects behind the reported one, both worse than lost watch coverage.

**1. `applyTarget` forgets a replica it created.** The periodic reconcile *does* already read every desired slot live via `Transport.Get` — so shape (1) from the triage largely exists. But `DecideConflict` classifies the result with `IsManagedReplica`, which requires *both* marks. Strip only `managed-by` and the engine's own replica lands in the "unmanaged foreign object" branch; with the default effective conflict policy of `Fail` that is `ActionFail`, and `fail(..., retry=false)` calls `removeEntry`. The entry is re-planned next pass and dropped again — an oscillation — and a `Replication` deleted in the wrong half of that cycle leaves a copy of the replicated Secret on the spoke with nothing tracking it.

**2. `collectGarbage` releases such an entry in silence.** Its safety gate (`!IsManagedReplica(...)` → "not ours, just drop the entry") cannot tell *"we never created this"* from *"we created this and someone relabelled it"*. Both were dropped with no event and no metric, which is exactly the "no code path may lose track of a created replica" the spec forbids. **This is the GC bug the triage asked about — found, and fixed here rather than filed.**

So the issue's "status keeps reporting ready" is not quite what happens today; what happens is a `Conflict` plus a stranded secret. Both are corrected.

## Shape chosen, and why

**Both (1) and (2) — but neither in the form the triage sketched, and that is the interesting part.**

- **(1) already exists; it was misinterpreted, not missing.** `applyTarget` reads every allowed slot live on every reconcile; `collectGarbage` reads every GC candidate before deleting. Between them, every inventory entry except revoked-retained ones is already verified. The fix is a three-state `ClassifyReplicaOwnership` (`Managed` / `Stripped` / `Foreign`) keyed on `r8r.io/source-uid` — a label nothing but this operator writes, on a UID that is neither guessable nor reused — so a relabelled replica is recognised as ours instead of misfiled.
- **(2) needs no cache probing.** "Not in the filtered cache" and "does not carry `managed-by: k8s-r8r`" are the same statement. Deriving the signal from the live read is strictly better than asking the informer: authoritative rather than eventually consistent, no false positives on cache lag or an unsynced informer, and no new plumbing from `DriftDetector` into the reconciler.

**Repairing the label is itself the fix for the blindness** — the re-apply puts the object back inside the cache's selector, so the watch resumes with no notification needed.

## Cost at 50 clusters × 500 replicas

| inventory entry class | live `Get` today | by |
|---|---|---|
| desired + policy-allowed | yes, every reconcile | `applyTarget` |
| not kept (deselected, renamed, revoked-`Delete`, deleting) | yes, before deleting | `collectGarbage` |
| revoked + retained | **no** | — (deliberate, D5) |

**The steady-state API cost of this fix is zero additional requests.** It adds a label comparison to reads that already happen.

The absolute numbers, for the record: 50 × 500 = 25,000 inventory entries, requeued at `--spoke-resync` (10h default), so the sweep already runs at **~0.7 spoke `GET`/s across the whole fleet** — ~0.014 rps per spoke API server. Unchanged by this PR. Worth stating precisely because the obvious reading of "verify every inventory member on every reconcile" would have *introduced* that load, and it turns out not to be needed. Extra cost appears only where something is wrong: one apply per tampered replica, bounded by tampering, not by fleet size. Hub-side: nothing — classification is a map lookup on labels already in memory.

**Detection latency stays bounded by `--spoke-resync`** (10h default). A dedicated shorter interval was considered and rejected: it needs a new flag in `cmd/main.go` (owned by #37 this sprint), a flag is a permanent API for a transient problem, and the repair is self-healing so the slow path runs once per tampering event. Operators needing a tighter bound already have `--spoke-resync`, which moves the informer resync and the periodic reconcile together — the correct coupling. **No new flag is needed; `cmd/main.go`, `internal/discovery/**` and the chart are untouched.**

## Interaction with #30

`k8s_r8r_drift_corrections_total` carries an invariant #30 wrote into its help string: *a non-zero value always means a replica's payload was actually wrong.* A stripped label over byte-identical content is metadata, not payload — counting it there would break that invariant for the same reason the annotation-only repair is excluded. So it is a **separate signal**:

```
k8s_r8r_replica_ownership_lost_total{cluster, action}   action ∈ repaired | deleted | orphaned
```

Both `cluster` and `action` are already on the metrics allowlist. The three actions answer different questions and must not be one counter — `orphaned` is the only one implying manual work, so it must be independently alertable.

**Both counters fire when both conditions hold.** A replica that lost its label *and* had its payload rewritten increments both and emits both `OwnershipRepaired` and `DriftCorrected`. That composition is the point: the counters stay independently meaningful, and the pair is the strongest tampering signature available.

Secret safety: messages carry object references, label names and `sha256:` hashes only. `TestNoPayloadFieldsInMessageFormatting` passes untouched; the new tests assert explicitly that no payload appears in any new message.

## OpenSpec

`openspec/changes/verify-replica-ownership/` — validates `--strict`.

- **`replication-engine`** — ADDS *Replica ownership verification*; MODIFIES *Inventory and garbage collection* (an entry is never released silently; verification uses both marks).
- **`observability-operations`** — ADDS *Replica ownership signals*.

The proposal notes that the existing drift requirements **implicitly assume the watch sees every inventoried replica** — "a hash mismatch or replica deletion observed via watch SHALL enqueue…" — which is precisely the assumption a rewritten `managed-by` breaks.

Deliberately uses ADDED requirements in `observability-operations` rather than restating *Prometheus metrics* / *Rate-limited structured events*: both are already modified by the unarchived `report-drift-corrections` change, and restating them would make whichever change syncs second silently discard the other's text. Folding the new signals into those two enumerations belongs to this sprint's archive pass.

## Verification

- `make test` — **290 tests green**, including 7 new engine cases and the classification table.
- `make lint` — **0 issues**. Verified against a pristine `git archive` export; `golangci-lint` from inside an agent worktree also analyses *sibling* worktrees and reported 6 phantom `SA5011`s from another agent's in-flight files. `origin/main` and this branch both report 0 in isolation. Nothing was "fixed" in files this PR does not touch.
- `make test-e2e` — **not run: no docker on this machine.** CI's `E2E (kind fleet, hub + 2 spokes)` job covers it. No e2e case was added for the label-strip path on purpose: e2e runs with the default 10h `--spoke-resync` and the eviction is invisible to the watch by construction, so it cannot be exercised there without a resync override. The existing "drift repair on replica edit/delete" cases still cover the unchanged watch path, and this is an engine change, so **please confirm CI's e2e job is green before merging.**

## Behaviour change to call out

A replica whose ownership label was rewritten is now **deleted** during cleanup, where it used to be abandoned. It only ever applies to an object carrying this replication's own source UID at the name its own inventory records. In the CHANGELOG.

Also expect existing fleets to start reporting ownership losses that were previously invisible — same shape as #30's rollout. Not new damage; previously unobservable damage.

## Obsidian handoff (this PR does not touch `obsidian/`)

For whoever owns the vault:

- **`obsidian/operations.md`** — Metrics: add `k8s_r8r_replica_ownership_lost_total{cluster,action}` with the three actions and the "alert on `orphaned`" guidance. Events: add `OwnershipRepaired`, `OwnershipStripped`, `ReplicaOrphaned` (all Warning, all on the `Replication`).
- **`obsidian/replication-flow.md`** — the apply path gains an ownership-classification step ahead of the conflict decision; the GC path's safety gate is now three-state (`Stripped` → delete, `Foreign` → reported release).
- **The drift/watch note** — state that `app.kubernetes.io/managed-by` is the spoke cache's selector, i.e. the watch's membership predicate, and that `r8r.io/source-uid` is the durable provenance mark verification keys on. Link the new `docs/security.md` subsection.
- **Security note** — the retained-replica exception: replicas retained under `revocationPolicy: Retain` are outside ownership verification by the same rule that puts them outside drift repair.
- Regenerate `graphify-out/` after merge (`graphify update .`); this PR deliberately leaves it untouched to avoid churn against parallel branches.

## File territory

Touched: `internal/engine/drift.go`, `internal/engine/reconciler.go`, `internal/engine/ownership_test.go` (new), `internal/telemetry/metrics.go`, `internal/telemetry/metrics_test.go`, `docs/security.md`, `CHANGELOG.md`, `openspec/changes/verify-replica-ownership/**`. **Not** touched: `cmd/main.go`, `internal/discovery/**`, the chart, `obsidian/`, `graphify-out/`. No CRD, RBAC, flag or `Replication` API change. Expect to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
